### PR TITLE
[NCL-2871] Don't report missing permissions as err

### DIFF
--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -107,7 +107,13 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
     # file tree, so this is a deduplicated operation. If the branch/tag
     # already exist, git will return quickly with an 0 (success) status
     # instead of uploading the objects.
-    yield from push_with_tags(expect_ok, repo_dir, branch_name)
+    try:
+        yield from push_with_tags(expect_ok, repo_dir, branch_name)
+    except exception.CommandError as e:
+        # Modify the exit code to 10. This tells Maitai to not treat this as
+        # a SYSTEM_ERROR (NCL-2871)
+        e.exit_code = 10
+        raise
 
     logger.info("Pushed to repo: branch {branch_name}, tag {tag_name}".format(**locals()))
 

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -105,7 +105,7 @@ def git_provider():
         def do(atomic):
             yield from expect_ok(
                 cmd=["git", "push"] + (["--atomic"] if atomic else []) + ["--follow-tags", remote, branch],
-                desc="Could not" + (" atomic" if atomic else "") + " push tag+branch with git. Make sure you have the right permissions!",
+                desc="Could not" + (" atomic" if atomic else "") + " push tag+branch with git. Make sure user 'pnc-user' has push permissions to this repository",
                 stderr=None,
                 cwd=dir
             )

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -105,7 +105,7 @@ def git_provider():
         def do(atomic):
             yield from expect_ok(
                 cmd=["git", "push"] + (["--atomic"] if atomic else []) + ["--follow-tags", remote, branch],
-                desc="Could not" + (" atomic" if atomic else "") + " push tag+branch with git",
+                desc="Could not" + (" atomic" if atomic else "") + " push tag+branch with git. Make sure you have the right permissions!",
                 stderr=None,
                 cwd=dir
             )


### PR DESCRIPTION
Currently repour reports `git push` failures with exit code 1. This exit
code is interpreted by Maitai as a SYSTEM_ERROR. We want to change this
to a 'build error' instead by returning exit code 10 instead (See NCL-2079)

This commit modifies the exit_code of the git push exception (if any) to
10, and improves the description error by telling the user it does not
have the required permissions to push.