### PR TITLE
[NCL-2896] Dont shw stacktrace for failed callback

### DIFF
--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -170,13 +170,13 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro):
                             ).encode("utf-8")
                         )
                     except Exception as e:
-                        logger.info(
+                        logger.error(
                             "Unable to send result of callback, exception {ename}, attempt {backoff}/{max_attempts}".format(
                                 ename=e.__class__.__name__,
                                 backoff=backoff,
                                 max_attempts=max_attempts,
                             ))
-                        log_traceback_multi_line()
+                        logger.error(e)
                         resp = None
                     return resp
 


### PR DESCRIPTION
Repour logs when a callback fails to be completed is outputing the full
stacktrace. This is annoying since it doesn't provide that much
information, we just really need to know the reason of the failed
callback.

This commit removes the full stacktrace and instead just prints the
reason of the failed callback. In my opinion, this will help increase
the readability of the logs.

See the JIRA for the full stacktrace.