### PR TITLE
[PNC-1.0.x] [NCL-2956] Make logs for pnc use same format

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -187,7 +187,7 @@ def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count
     logging.setLogRecordFactory(ContextLogRecord)
 
     formatter = logging.Formatter(
-        fmt="{asctime} [{log_context}] {levelname} {name}:{lineno} {message}",
+        fmt="{asctime} [{levelname}] [{log_context}] {name}:{lineno} {message}",
         style="{",
     )
 


### PR DESCRIPTION
Format is:

     <yyyy-mm-dd> HH:mm:ss,SSS [Log level] Extra logs