### PR TITLE
[NCL-2948] Dont' create branches on /adjust

### DIFF
--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -88,8 +88,6 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
 
     # Apply the actual branch name now we know the commit ID
     operation_name_lower = operation_name.lower()
-    branch_name = "branch-{operation_name_lower}-{commit_id}".format(**locals())
-    yield from replace_branch(expect_ok, repo_dir, temp_branch, branch_name)
 
     tag_name = "repour-{commit_id}".format(**locals())
 
@@ -104,11 +102,11 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
             raise
 
     # The tag and reference names are set up to be the same for the same
-    # file tree, so this is a deduplicated operation. If the branch/tag
+    # file tree, so this is a deduplicated operation. If the tag
     # already exist, git will return quickly with an 0 (success) status
     # instead of uploading the objects.
     try:
-        yield from push_with_tags(expect_ok, repo_dir, branch_name)
+        yield from push_with_tags(expect_ok, repo_dir, None)
     except exception.CommandError as e:
         # Modify the exit code to 10. This tells Maitai to not treat this as
         # a SYSTEM_ERROR (NCL-2871)

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -100,12 +100,21 @@ def git_provider():
         this method re-tries without it and returns false.
         If an exception is thrown, some other error occurred and push did not
         succeed.
+
+        If branch is None, it is assumed that you only want to push the tags
         """
 
         def do(atomic):
+            if branch is None:
+                options = ["--tags"]
+                failure_push_msg = "tag"
+            else:
+                options = ["--follow-tags", remote, branch]
+                failure_push_msg = "tag+branch"
+
             yield from expect_ok(
-                cmd=["git", "push"] + (["--atomic"] if atomic else []) + ["--follow-tags", remote, branch],
-                desc="Could not" + (" atomic" if atomic else "") + " push tag+branch with git. Make sure user 'pnc-user' has push permissions to this repository",
+                cmd=["git", "push"] + (["--atomic"] if atomic else []) + options,
+                desc="Could not" + (" atomic" if atomic else "") + " push " + failure_push_msg + " with git. Make sure user 'pnc-user' has push permissions to this repository",
                 stderr=None,
                 cwd=dir
             )


### PR DESCRIPTION
The original intention of creating tags and branches for a commit on
'/adjust' was to use tags for everything, and possibly do manual changes
to the branch if we require so.

However, we think that the creation of branches is unecessary since we
don't really use it, and if we have to, we can manually create the
branch from the tag