### PR TITLE
git push fails because tag already exists, is fine

### DIFF
--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -132,6 +132,8 @@ def git_provider():
                 logger.warn("The repository provider does not support atomic push. "
                             "There is a risk of tag/branch inconsistency.")
                 yield from do(False)
+            elif "Updates were rejected because the tag already exists in the remote" in e.stderr:
+                logger.info("git push failed because tag already exists. There is no need to worry")
             else:
                 raise
 


### PR DESCRIPTION
Because we do not create branches anymore for /adjust, I had to change
the git push command to:

```
git push --tags
```

Sometimes this command will fail if the tag already exists on the remote
server (this situation happens because we do a shallow clone, and that
clone doesn't have all the tags in the remote server). This is fine
because that means that the tag that already exists will have the same
content as the tag created locally. So it's ok that the push failed.