### PR TITLE
[NCL-2882] Send live logs of repour operations

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -561,6 +561,11 @@ The body of the usual "Success" or "Processing error" response will then be sent
 }
 |===
 
+=== Callback websocket for live logs
+
+All endpoints that operate in callback mode can be eligible for live logs via websockets. Once the callback id is obtained, you can establish a websocket connection to `/callback/{callback_id}`. The server will then push any logs back to the client. The logs are in string format.
+
+
 == Docker Images and Open Shift
 
 There are two docker images defined in this repository:

--- a/repour/logs/file_callback_log.py
+++ b/repour/logs/file_callback_log.py
@@ -1,0 +1,43 @@
+import asyncio
+import logging
+import os
+
+CALLBACK_LOGS_PATH = '/tmp/repour-logs-callback'
+
+
+def get_callback_log_path(callback_id):
+    return os.path.join(CALLBACK_LOGS_PATH, callback_id + '.log')
+
+
+class FileCallbackHandler(logging.StreamHandler):
+    """
+    Handler that logs into {directory}/{callback_id}.log
+    """
+    def __init__(self, directory=CALLBACK_LOGS_PATH, mode='a', encoding=None, delay=None):
+        if os.path.exists(directory):
+            if not os.path.isdir(directory):
+                raise Exception(directory + " is not a directory! Can't log there")
+        else:
+            os.makedirs(directory)
+
+        self.filename = directory
+        self.mode = mode
+        self.encoding = encoding
+        self.delay = delay
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        try:
+            task = asyncio.Task.current_task()
+
+            if task is not None:
+                callback_id = getattr(task, "callback_id", None)
+                if callback_id is not None:
+                    self.stream = self._open_callback_file(callback_id)
+                    logging.StreamHandler.emit(self, record)
+        except:
+            self.handleError(record)
+
+    def _open_callback_file(self, callback_id):
+        path = os.path.join(self.filename, callback_id + ".log")
+        return open(path, self.mode, encoding=self.encoding)

--- a/repour/logs/websocket_log.py
+++ b/repour/logs/websocket_log.py
@@ -1,0 +1,19 @@
+import asyncio
+import logging
+
+from .. import websockets
+
+class WebsocketLoggerHandler(logging.Handler):
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            task = asyncio.Task.current_task()
+
+            if task is not None:
+                callback_id = getattr(task, "callback_id", None)
+                if callback_id is not None:
+                    asyncio.get_event_loop().create_task(
+                    websockets.send(callback_id, msg))
+        except:
+            self.handleError(record)

--- a/repour/main.py
+++ b/repour/main.py
@@ -4,6 +4,9 @@ import logging
 import os
 import sys
 
+from .logs import file_callback_log
+from .logs import websocket_log
+
 logger = logging.getLogger(__name__)
 
 class ContextLogRecord(logging.LogRecord):
@@ -191,6 +194,11 @@ def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count
         style="{",
     )
 
+    formatter_callback = logging.Formatter(
+        fmt="[{levelname}] {name}:{lineno} {message}",
+        style="{",
+    )
+
     root_logger = logging.getLogger()
 
     if log_path is not None:
@@ -202,6 +210,14 @@ def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count
         console_log = logging.StreamHandler()
         console_log.setFormatter(formatter)
         root_logger.addHandler(console_log)
+
+    ws_log = websocket_log.WebsocketLoggerHandler()
+    ws_log.setFormatter(formatter_callback)
+    root_logger.addHandler(ws_log)
+
+    callback_id_log = file_callback_log.FileCallbackHandler()
+    callback_id_log.setFormatter(formatter_callback)
+    root_logger.addHandler(callback_id_log)
 
     log_level = default_level + (10 * quiet_count) - (10 * verbose_count)
     root_logger.setLevel(log_level)

--- a/repour/server/endpoint/ws.py
+++ b/repour/server/endpoint/ws.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from aiohttp import web
+from ... import websockets
+
+
+@asyncio.coroutine
+def handle_socket(request):
+    """ Websocket handler for live logs. Expects to receive the callback_id
+        as part of the request
+
+        Request: ws://<link>/ws/<callback_id>
+    """
+
+    callback_id = request.match_info['callback_id']
+    ws_obj = web.WebSocketResponse(autoping=True)
+
+    yield from ws_obj.prepare(request)
+    yield from websockets.register(callback_id, asyncio.Task.current_task(), ws_obj)
+
+    # Keep websocket alive if client hasn't closed it yet
+    while True:
+        if not ws_obj.closed:
+            yield from asyncio.sleep(10)
+        else:
+            break
+
+    return ws

--- a/repour/websockets.py
+++ b/repour/websockets.py
@@ -1,0 +1,113 @@
+import asyncio
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Global object with key: callback_id and
+# value (asyncio_task, websocket_handler)
+websocket_handlers = {}
+
+@asyncio.coroutine
+def register(callback_id, task, websocket_handler):
+    """ Register a websocket handler with a callback_id and the task where
+        the websocket handler was spawn
+
+        We are going to use this information in the `send` function to send
+        log events for a particular callback to the appropriate websocket.
+
+        We need to get the task because that's the only way to figure out if a
+        websocket is closed or not. If the task is done, the websocket is closed
+
+        Parameters:
+        - callback_id: :str: id
+        - task: :asyncio_task: task where websocket handler created
+        - websocket_handler: :aiohttp_websocket: websocket handler
+
+        Returns:
+        - None
+    """
+    global websocket_handlers
+
+    if callback_id not in websocket_handlers:
+        websocket_handlers[callback_id] = [(task, websocket_handler)]
+    else:
+        websocket_handlers[callback_id].append((task, websocket_handler))
+
+
+@asyncio.coroutine
+def periodic_cleanup():
+    """ Cleanup the websocket_handlers datastructure by removing closed
+        websocket handlers and callback_ids with empty websocket list
+
+        It runs every 30 seconds. It needs to be launched inside its own task
+
+        Parameters:
+        - None
+
+        Returns:
+        - None
+    """
+    global websocket_handlers
+
+    while True:
+
+        # find already closed websocket_handlers and remove them from list of
+        # 'active' handlers
+        for callback_id in websocket_handlers:
+            handlers = websocket_handlers[callback_id]
+            for task, handler in handlers:
+                if task.done():
+                    logger.debug("Removing websocket handler for id: " + callback_id)
+                    handlers.remove((task, handler))
+
+        to_remove_callback_id = []
+
+        # Search for callback_id with no handlers, and delete them
+        for callback_id in websocket_handlers:
+            if len(websocket_handlers[callback_id]) == 0:
+                to_remove_callback_id.append(callback_id)
+
+        for callback_id in to_remove_callback_id:
+            del websocket_handlers[callback_id]
+        yield from asyncio.sleep(30)
+
+
+@asyncio.coroutine
+def send(callback_id, message):
+    """ Send the message to the websocket handlers linked to a callback_id
+
+        Parameters:
+        - callback_id: :str: id
+        - message: :str: message to send
+
+        Returns:
+        - None
+    """
+    global websocket_handlers
+
+    if callback_id in websocket_handlers:
+        handlers = websocket_handlers[callback_id]
+
+        for task, handler in handlers:
+            # (cleanup) if task of websocket is closed, that means websocket
+            # closed. no need to send events to that closed websocket
+            if task.done():
+                handlers.remove((task, handler))
+            else:
+                yield from handler.send_str(message)
+
+
+@asyncio.coroutine
+def close(callback_id):
+    """ Delete all the websocket handler information for a callback_id
+
+        Parameters:
+        - callback_id: :str: id
+
+        Returns:
+        - None
+    """
+    global websocket_handlers
+
+    del websocket_handlers[callback_id]


### PR DESCRIPTION
The live logs will only work when the operation is done in callback
mode. In callback mode, the callback id is sent to the requestor. The
requestor can then use that callback id to connect to a websocket
endpoint and receive live logs.

The websocket endpoint is:

```
ws://<server>:<port>/callback/{callback_id}
```

This is achieved by adding a logger handler that receives the logs, and
sends them to the websocket clients.

There is another logger handler used to capture the logs for specific
callback ids and save them into individual files. The aim is to be able
to forward to the requestor the relevant logs for that particular callback
id, beyond using websockets.

There is also a function that is activated. Its goal is to cleanup the
closed websockets that repour is sending logs if the websockets are
already closed. This helps prevent any memory leak that might happen if
we keep track of the closed websockets.