### PR TITLE
[NCL-2882] Send back websocket link to requestor

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -77,6 +77,7 @@ def run_container_subcommand(args):
             missing_envs.append((name, desc))
         return val
     da_url = required_env("REPOUR_PME_DA_URL", "The REST endpoint required by PME to look up GAVs")
+    repour_url = required_env("REPOUR_URL", "Repour's URL")
 
     # Mode B
     if args.mode_b:
@@ -134,6 +135,7 @@ def run_container_subcommand(args):
             "port": 7331,
         },
         repo_provider = repo_provider,
+        repour_url = repour_url,
         adjust_provider = {
             "type": "subprocess",
             "params": {

--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -57,7 +57,7 @@ def log_traceback_multi_line():
             logger.error(line)
 
 
-def validated_json_endpoint(shutdown_callbacks, validator, coro):
+def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):
     client_session = aiohttp.ClientSession()  # pylint: disable=no-member
     shutdown_callbacks.append(client_session.close)
 
@@ -220,6 +220,7 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro):
             obj = {
                 "callback": {
                     "id": callback_id,
+                    "websocket": "ws://" + repour_url + "/callback/" + callback_id
                 }
             }
 

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -25,7 +25,7 @@ shutdown_callbacks = []
 
 
 @asyncio.coroutine
-def init(loop, bind, repo_provider, adjust_provider):
+def init(loop, bind, repo_provider, repour_url, adjust_provider):
     logger.debug("Running init")
     c = yield from config.get_configuration()
 
@@ -39,16 +39,16 @@ def init(loop, bind, repo_provider, adjust_provider):
 
     if repo_provider["type"] == "modeb":
         logger.warn("Mode B selected, guarantees rescinded")
-        pull_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.pull_modeb, pull.pull)
-        adjust_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.adjust_modeb, adjust.adjust)
+        pull_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.pull_modeb, pull.pull, repour_url)
+        adjust_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.adjust_modeb, adjust.adjust, repour_url)
     else:
-        pull_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.pull, pull.pull)
-        adjust_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.adjust, adjust.adjust)
+        pull_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.pull, pull.pull, repour_url)
+        adjust_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.adjust, adjust.adjust, repour_url)
 
     logger.debug("Setting up handlers")
     app.router.add_route("POST", "/pull", pull_source)
     app.router.add_route("POST", "/adjust", adjust_source)
-    app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone))
+    app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))
     app.router.add_route("POST", "/cancel", cancel.handle_cancel)
     app.router.add_route("GET", "/callback/{callback_id}", ws.handle_socket)
 
@@ -58,7 +58,7 @@ def init(loop, bind, repo_provider, adjust_provider):
         logger.info("Server started on socket: {}".format(socket.getsockname()))
 
 
-def start_server(bind, repo_provider, adjust_provider):
+def start_server(bind, repo_provider, repour_url, adjust_provider):
     logger.debug("Starting server")
     loop = asyncio.get_event_loop()
 
@@ -71,6 +71,7 @@ def start_server(bind, repo_provider, adjust_provider):
         loop=loop,
         bind=bind,
         repo_provider=repo_provider,
+        repour_url=repour_url,
         adjust_provider=adjust_provider,
     ))
 


### PR DESCRIPTION
This commit requires the user to define an Environment variable named
'REPOUR_URL'. The value of that variable will be the external url of
repour, for e.g 'repour.somewhere.in.the.cloud'

The websocket link is only sent when callback mode is used.

The callback reply will look like:
```
{
    "callback": {
        "id": "fancy-id",
        "websocket": "ws://pnc-repour.instance.magic/callback/fancy-id"
    }
}
```