### PR TITLE
[NCL-3005] Adjust from internal hash

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -41,7 +41,8 @@ def adjust(adjustspec, repo_provider):
 
         repo_url = yield from repo_provider(adjustspec, create=False)
 
-        yield from git["clone_checkout_branch_tag_shallow"](work_dir, repo_url.readwrite, adjustspec["ref"])
+        yield from git["clone"](work_dir, repo_url.readwrite)  # Clone origin
+        yield from git["checkout"](work_dir, adjustspec["ref"])  # Checkout ref
 
         yield from asgit.setup_commiter(expect_ok, work_dir)
 


### PR DESCRIPTION
Currently for the `/adjust` endpoint, if hte ref is a hash, `/adjust` doesn't work. This commit fixes it.