### PR TITLE
[NCL-3041] Update to handle scm user on its own

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -40,8 +40,8 @@ def adjust(adjustspec, repo_provider):
     with asutil.TemporaryDirectory(suffix="git") as work_dir:
 
         repo_url = yield from repo_provider(adjustspec, create=False)
-
-        yield from git["clone"](work_dir, repo_url.readwrite)  # Clone origin
+        git_user = c.get("git_username")
+        yield from git["clone"](work_dir, asutil.add_username_url(repo_url.readwrite, git_user))  # Clone origin
         yield from git["checkout"](work_dir, adjustspec["ref"])  # Checkout ref
 
         yield from asgit.setup_commiter(expect_ok, work_dir)

--- a/repour/asutil.py
+++ b/repour/asutil.py
@@ -171,3 +171,22 @@ def expect_ok_closure(exc_type=exception.CommandError):
                     return _convert_bytes(stdout_data, stdout)
 
     return expect_ok
+
+
+def add_username_url(url, username):
+    """ Given a url, add username to the url if not already in url
+
+    returns: :str: url with username
+    """
+    parsed = urllib.parse.urlsplit(url)
+
+    if parsed.username:
+        # username info already in url, all good!
+        return url
+    else:
+        parsed_list = list(parsed)
+        # first item is the protocol, second is the url name
+        url_part = parsed_list[1]
+        parsed_list[1] = username + '@' + url_part
+
+        return urllib.parse.urlunsplit(parsed_list)

--- a/repour/clone.py
+++ b/repour/clone.py
@@ -4,6 +4,7 @@ import os
 
 from . import asutil
 from . import exception
+from .config import config
 from .scm import git_provider
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,10 @@ def clone(clonespec, repo_provider):
 def clone_git(clonespec):
     with asutil.TemporaryDirectory(suffix="git") as clone_dir:
 
-        yield from git["clone"](clone_dir, clonespec["originRepoUrl"])  # Clone origin
+        c = yield from config.get_configuration()
+        git_user = c.get("git_username")
+
+        yield from git["clone"](clone_dir, asutil.add_username_url(clonespec["originRepoUrl"], git_user))  # Clone origin
         yield from git["checkout"](clone_dir, clonespec["ref"])  # Checkout ref
         yield from git["add_remote"](clone_dir, "target", clonespec["targetRepoUrl"])  # Add target remote
         branch = clonespec["ref"]

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -28,5 +28,6 @@
       "user.name": "Repour",
       "user.email": "<>"
     }
-  }
+  },
+  "git_username": "<>"
 }

--- a/repour/pull.py
+++ b/repour/pull.py
@@ -8,6 +8,7 @@ from . import asgit
 from . import asutil
 from . import exception
 from .adjust import adjust
+from .config import config
 from .scm import git_provider
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,11 @@ git = git_provider.git_provider()
 def to_internal(internal_repo_url, dirname, origin_ref, origin_url, origin_type):
     # Prepare new repo
     # Note that for orphan branches, we don't need to clone the existing internal repo first
+
+    c = yield from config.get_configuration()
+    git_user = c.get("git_username")
     yield from git["init"](dirname)
-    yield from git["add_remote"](dirname, "origin", internal_repo_url.readwrite)
+    yield from git["add_remote"](dirname, "origin", asutil.add_username_url(internal_repo_url.readwrite, git_user))
 
     yield from asgit.setup_commiter(expect_ok, dirname)
     d = yield from asgit.push_new_dedup_branch(


### PR DESCRIPTION
The Git url that we receive from the request might not have the username
in it anymore. This makes sense because Repour is configured to clone
repositories from a specific user, as repour is running with the private
keys of that specific user.

As such, the username of the git url we receive is _always_ for that
specific user. So it makes sense to just omit the username in the git
url we receive, and let repour add it implicitly instead. In that way,
if the specific user repour uses has to change, we only have to do the
change in repour, and not in the various clients of repour.