### PR TITLE
[NCL-2981] Add endpoint /cloneadjust

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -490,7 +490,82 @@ The response will contain the resulting ref name.
     "originRepoUrl": Url(),
     "targetRepoUrl": Url(),
 }
+!===
+|===
 
+=== Clone Adjust
+
+Checkout a git ref from the origin repo and push it to the target repo.
+If the ref is a branch, the branch will be pushed to the target repo. If the ref is a tag, the tag will be pushed to the target repo. If the ref is a SHA, then a branch will be created with name 'branch-<ref>' and pushed as a branch to the target repo. The latter is required to get a particular commit to the target repo.
+
+You can specify an 'adjust' option to set if you want to run PME or not on it. You can also specify the 'adjustParameters'. The result of the PME run, together with the tag information is found in the response, under key 'adjust_result'. The value of 'adjust_result' is the same as for '/adjust'.
+
+The response will contain the exact ref name as what was sent
+
+[cols="h,6a"]
+|===
+|URL
+|/cloneadjust
+
+|Request
+|[cols="h,4a"]
+!===
+!Method
+!POST
+
+!Content-Type
+!application/json
+
+!Body (Schema)
+![source,python]
+{
+    "type": "git", # only git supported for now
+    "ref": nonempty_str,
+    "originRepoUrl": Url(),
+    "internal_url": {
+        "readwrite": Url(),
+        "readonly": Url()
+    },
+    Optional("adjust"): bool,
+    Optional("adjustParameters"): All(dict),
+    Optional("callback"): {
+        "url": Url(),
+        Optional("method"): Any("PUT", "POST"),
+    }
+}
+
+!===
+
+|Response (Success)
+|[cols="h,4a"]
+!===
+!Status
+!200
+
+!Content-Type
+!application/json
+
+!Body (Schema)
+![source,python]
+{
+    "type": "git", # only git supported for now
+    "ref": nonempty_str,
+    "originRepoUrl": Url(),
+    "internal_url": {
+        "readwrite": Url(),
+        "readonly": Url()
+    },
+    Optional("adjust"): bool,
+    Optional("adjustParameters"): All(dict),
+    "adjust_result": {
+        "tag": str,
+        "url": {
+            "readwrite": Url(),
+            "readonly": Url(),
+        },
+        "adjustResultData": str
+    }
+}
 !===
 |===
 

--- a/repour/cloneadjust.py
+++ b/repour/cloneadjust.py
@@ -1,0 +1,74 @@
+import asyncio
+import logging
+import os
+
+from . import asutil
+from . import exception
+from .adjust import adjust
+from .scm import git_provider
+
+logger = logging.getLogger(__name__)
+
+#
+# Utility
+#
+
+expect_ok = asutil.expect_ok_closure(exception.CommandError)
+
+git = git_provider.git_provider()
+
+@asyncio.coroutine
+def cloneadjust(clonespec, repo_provider):
+    if clonespec["type"] in scm_types:
+        internal = yield from scm_types[clonespec["type"]](clonespec, repo_provider, adjust.adjust)
+    else:
+        raise exception.CloneError("Type '{clonespec[type]}' not supported for 'clone' operation.".format(**locals()))
+
+    return internal
+
+
+@asyncio.coroutine
+def clone_adjust_git(clonespec, repo_provider, adjust_provider):
+    with asutil.TemporaryDirectory(suffix="git") as clone_dir:
+
+        internal_repo_url = yield from repo_provider(clonespec)
+        yield from git["clone"](clone_dir, clonespec["originRepoUrl"])  # Clone origin
+        yield from git["checkout"](clone_dir, clonespec["ref"])  # Checkout ref
+        yield from git["add_remote"](clone_dir, "target", internal_repo_url.readwrite)  # Add target remote
+
+        ref = clonespec["ref"]
+
+        isRefBranch = yield from git["is_branch"](clone_dir, ref)  # if ref is a branch, we don't have to create one
+        isRefTag = yield from git["is_tag"](clone_dir, ref)
+
+        if isRefBranch:
+            yield from git["push"](clone_dir, "target", ref)  # push it to the remote
+        elif isRefTag:
+            yield from git["push_with_tags"](clone_dir, ref, remote="target")
+        else:
+            # Case if ref is a particular SHA
+            # We can't really push a particular hash to the target repository
+            # unless it is in a branch. We have to create the branch to be able
+            # to push the SHA
+            branch = "branch-" + ref
+            yield from git["add_branch"](clone_dir, branch)
+            yield from git["push"](clone_dir, "target", branch)  # push it to the remote
+
+        do_adjust = clonespec.get("adjust", False)
+        adjust_param = clonespec.get("adjustParameters", False)
+
+        if do_adjust:
+            # TODO: this re-clones the repository to run PME, there must be a
+            #       better way
+            adjust_type = yield from adjust_provider(clonespec, repo_provider)
+
+            clonespec["adjust_result"] = adjust_type
+        else:
+            clonespec["adjust_result"] = None
+
+        return clonespec
+
+scm_types = {
+    "git": clone_adjust_git,
+}
+

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -128,6 +128,26 @@ clone = Schema(
 )
 
 #
+# Clone Adjust
+#
+
+clone_adjust_raw = {
+    "name": name_str,
+    "type": "git", # only git supported for now
+    "ref": nonempty_str,
+    "originRepoUrl": Url(),
+    Optional("adjust"): bool,
+    Optional("adjustParameters"): All(dict),
+    Optional("callback"): callback_raw,
+}
+
+clone_adjust = Schema(
+    mode_b_ify(clone_adjust_raw),
+    required = True,
+    extra = False,
+)
+
+#
 # Returns
 #
 

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -8,6 +8,7 @@ from .endpoint import endpoint
 from .endpoint import ws
 from ..adjust import adjust
 from .. import clone
+from .. import cloneadjust
 from .. import pull
 from .. import repo
 from .. import websockets
@@ -48,6 +49,7 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
     logger.debug("Setting up handlers")
     app.router.add_route("POST", "/pull", pull_source)
     app.router.add_route("POST", "/adjust", adjust_source)
+    app.router.add_route("POST", "/cloneadjust", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone_adjust, cloneadjust.cloneadjust, repour_url))
     app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))
     app.router.add_route("POST", "/cancel", cancel.handle_cancel)
     app.router.add_route("GET", "/callback/{callback_id}", ws.handle_socket)


### PR DESCRIPTION
This endpoint allows a user to sync and optionally run PME on the
output.

If the ref is a branch, the branch will be pushed to the target repo. If
the ref is a tag, the tag will be pushed to the target repo. If the ref
is a SHA, a branch will be created and named 'branch-<ref>' and pushed
to the target repo. The latter is required to get a particular commit to
the target repository.

The adjust parameter, when enabled, will run PME, and the result is put
inside the response in key 'adjust_result'. The content of
'adjust_result' is exactly the same as the output for the '/adjust'
endpoint.