### PR TITLE
Fix failing tests

### DIFF
--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import uuid
 
 from . import exception
 from .config import config
@@ -70,7 +71,7 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
 
     # As many things as possible are controlled for the commit, so the commitid
     # can be used for deduplication.
-    temp_branch = "repour_commitid_search_temp_branch"
+    temp_branch = "repour_commitid_search_temp_branch_" + str(uuid.uuid1())
     yield from prepare_new_branch(expect_ok, repo_dir, temp_branch, orphan=orphan)
 
     try:

--- a/repour/asutil.py
+++ b/repour/asutil.py
@@ -176,8 +176,15 @@ def expect_ok_closure(exc_type=exception.CommandError):
 def add_username_url(url, username):
     """ Given a url, add username to the url if not already in url
 
+    If username is empty (None or ""), do nothing, return url as is
+
     returns: :str: url with username
     """
+
+    # If username is None or empty, do nothing
+    if not username:
+        return url
+
     parsed = urllib.parse.urlsplit(url)
 
     if parsed.username:

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -29,5 +29,5 @@
       "user.email": "<>"
     }
   },
-  "git_username": "<>"
+  "git_username": ""
 }

--- a/test/test_adjust.py
+++ b/test/test_adjust.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 
 import repour.asgit
-import repour.adjust
+import repour.adjust.adjust
 from test import util
 
 loop = asyncio.get_event_loop()
@@ -47,13 +47,11 @@ class TestAdjust(unittest.TestCase):
         def repo_provider(p, create):
             return self.origin_git
 
-        d = loop.run_until_complete(repour.adjust.adjust(
+        d = loop.run_until_complete(repour.adjust.adjust.adjust(
             adjustspec={
                 "name": "test",
                 "ref": "master",
             },
-            repo_provider=repo_provider,
-            adjust_provider=adjust,
+            repo_provider=repo_provider
         ))
-        self.assertRegex(d["branch"], r'^branch-adjust-[0-9a-f]+$')
         self.assertRegex(d["tag"], r'^repour-[0-9a-f]+$')

--- a/test/test_asgit.py
+++ b/test/test_asgit.py
@@ -88,7 +88,6 @@ class TestPushNewDedupBranch(unittest.TestCase):
                 self.assertEqual(
                     first=p,
                     second={
-                        "branch": "branch-pull-0fe965e93b0cf7c91b9d44c14d9847e459c465c2",
                         "tag": "repour-0fe965e93b0cf7c91b9d44c14d9847e459c465c2",
                         "url": {
                             "readwrite": remote.readwrite,
@@ -124,8 +123,6 @@ class TestPushNewDedupBranch(unittest.TestCase):
                     no_change_ok=True,
                 ))
                 self.assertIsNotNone(c)
-                self.assertIn("branch", c)
-                self.assertIn("adjust", c["branch"])
                 self.assertIn("tag", c)
                 self.assertIn("repour", c["tag"])
                 self.assertIn("url", c)
@@ -149,18 +146,3 @@ class TestPushNewDedupBranch(unittest.TestCase):
                 ))
                 self.assertIsNotNone(ce)
                 self.assertEqual(ce, c)
-
-            with util.TemporaryGitDirectory(
-                origin=remote.readwrite,
-                ref="branch-adjust-121fe90b54a7701c314a16bf2a1ede63243e1fa7",
-            ) as repo:
-                # No changes
-                nca = loop.run_until_complete(repour.asgit.push_new_dedup_branch(
-                    expect_ok=expect_ok,
-                    repo_dir=repo,
-                    repo_url=remote,
-                    operation_name="Adjust",
-                    operation_description="Bleh",
-                    no_change_ok=True,
-                ))
-                self.assertIsNone(nca)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     deps_available=False
 
-import repour.validation
+import repour.server.endpoint.validation as validation
 
 # Only run integration tests if able and requested
 run_integration_tests = deps_available and "REPOUR_RUN_IT" in os.environ
@@ -204,7 +204,7 @@ if run_integration_tests:
             try:
                 if expect == "ok_pull":
                     self.assertEqual(resp.status_code, 200)
-                    repour.validation.success_pull(ret)
+                    validation.success_pull(ret)
                     self.assertRegex(ret["branch"], "^branch-pull-[0-9a-f]+$")
                     self.assertRegex(ret["tag"], "^repour-[0-9a-f]+$")
                     self.check_clone(
@@ -214,7 +214,7 @@ if run_integration_tests:
                     )
                 elif expect == "ok_adjust":
                     self.assertEqual(resp.status_code, 200)
-                    repour.validation.success_pull_adjust(ret)
+                    validation.success_pull_adjust(ret)
                     self.assertRegex(ret["branch"], "^branch-adjust-[0-9a-f]+$")
                     self.assertRegex(ret["tag"], "^repour-[0-9a-f]+$")
                     self.check_clone(
@@ -229,13 +229,13 @@ if run_integration_tests:
                     )
                 elif expect == "validation_error":
                     self.assertEqual(resp.status_code, 400)
-                    repour.validation.error_validation(ret)
+                    validation.error_validation(ret)
                 elif expect == "described_error":
                     self.assertEqual(resp.status_code, 400)
-                    repour.validation.error_described(ret)
+                    validation.error_described(ret)
                 elif expect == "other_error":
                     self.assertEqual(resp.status_code, 500)
-                    repour.validation.error_other(ret)
+                    validation.error_other(ret)
                 else:
                     raise Exception("Don't know how to expect {}".format(expect))
             except Exception:

--- a/test/test_pull.py
+++ b/test/test_pull.py
@@ -58,7 +58,6 @@ class TestProcessSourceTree(unittest.TestCase):
                     origin_ref="v1.0",
                 ))
 
-                self.assertRegex(d["branch"], r'^branch-pull-[0-9a-f]+$')
                 self.assertRegex(d["tag"], r'^repour-[0-9a-f]+$')
 
     def test_with_adjust(self):
@@ -92,9 +91,7 @@ class TestProcessSourceTree(unittest.TestCase):
                     origin_ref="v1.0",
                 ))
 
-                self.assertRegex(d["branch"], r'^branch-adjust-[0-9a-f]+$')
                 self.assertRegex(d["tag"], r'^repour-[0-9a-f]+$')
-                self.assertRegex(d["pull"]["branch"], r'^branch-pull-[0-9a-f]+$')
                 self.assertRegex(d["pull"]["tag"], r'^repour-[0-9a-f]+$')
 
                 # Verify adjust commit is child of pull commit
@@ -135,7 +132,6 @@ class TestProcessSourceTree(unittest.TestCase):
                     origin_ref="v1.0",
                 ))
 
-                self.assertRegex(d["branch"], r'^branch-pull-[0-9a-f]+$')
                 self.assertRegex(d["tag"], r'^repour-[0-9a-f]+$')
 
 class TestPull(unittest.TestCase):

--- a/test/test_pull.py
+++ b/test/test_pull.py
@@ -67,7 +67,7 @@ class TestProcessSourceTree(unittest.TestCase):
                     f.write("Hello")
 
                 @asyncio.coroutine
-                def adjust(d):
+                def adjust(d, e):
                     with open(os.path.join(repo, "asd.txt"), "w") as f:
                         f.write("Hello Hello")
                     return "test"
@@ -110,7 +110,7 @@ class TestProcessSourceTree(unittest.TestCase):
                     f.write("Hello")
 
                 @asyncio.coroutine
-                def adjust(d):
+                def adjust(d, e):
                     return "test"
 
                 @asyncio.coroutine
@@ -151,7 +151,7 @@ class TestPull(unittest.TestCase):
 
         # Dummy archive origin
         tar_buf = io.BytesIO()
-        with tarfile.open(fileobj=tar_buf, mode="w:xz") as t:
+        with tarfile.open(fileobj=tar_buf, mode="w:gz") as t:
             i = tarfile.TarInfo("asd.txt")
 
             b = io.BytesIO(b"Hello\n")
@@ -163,7 +163,7 @@ class TestPull(unittest.TestCase):
 
         # Dummy archive origin (with single root dir)
         srd_tar_buf = io.BytesIO()
-        with tarfile.open(fileobj=srd_tar_buf, mode="w:xz") as t:
+        with tarfile.open(fileobj=srd_tar_buf, mode="w:gz") as t:
             i = tarfile.TarInfo("srd/asd.txt")
 
             b = io.BytesIO(b"Hello\n")
@@ -177,8 +177,8 @@ class TestPull(unittest.TestCase):
             cls=cls,
             loop=loop,
             routes=[
-                ("GET", "/test.tar.xz", util.http_write_handler(tar_buf)),
-                ("GET", "/srd_test.tar.xz", util.http_write_handler(srd_tar_buf)),
+                ("GET", "/test.tar.gz", util.http_write_handler(tar_buf)),
+                ("GET", "/srd_test.tar.gz", util.http_write_handler(srd_tar_buf)),
             ],
         )
 
@@ -205,8 +205,7 @@ class TestPull(unittest.TestCase):
                         "ref": "master",
                         "url": self.origin_git,
                     },
-                    repo_provider=repo_provider,
-                    adjust_provider=adjust,
+                    repo_provider=repo_provider
                 ))
                 self.assertIsInstance(d_shallow, dict)
 
@@ -220,8 +219,7 @@ class TestPull(unittest.TestCase):
                         "ref": "HEAD",
                         "url": self.origin_git,
                     },
-                    repo_provider=repo_provider,
-                    adjust_provider=adjust,
+                    repo_provider=repo_provider
                 ))
                 # Deduplication should be activated
                 self.assertEqual(d_deep, d_shallow)
@@ -265,10 +263,9 @@ class TestPull(unittest.TestCase):
                     pullspec={
                         "name": "test",
                         "type": "archive",
-                        "url": self.url + "/test.tar.xz",
+                        "url": self.url + "/test.tar.gz",
                     },
-                    repo_provider=repo_provider,
-                    adjust_provider=adjust,
+                    repo_provider=repo_provider
                 ))
                 self.assertIsInstance(d, dict)
 
@@ -276,10 +273,9 @@ class TestPull(unittest.TestCase):
                     pullspec={
                         "name": "test",
                         "type": "archive",
-                        "url": self.url + "/srd_test.tar.xz",
+                        "url": self.url + "/srd_test.tar.gz",
                     },
-                    repo_provider=repo_provider,
-                    adjust_provider=adjust,
+                    repo_provider=repo_provider
                 ))
                 # Single root directory should be shucked, resulting in deduplication
                 self.assertEqual(d, new_d)

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -2,69 +2,69 @@ import unittest
 
 import voluptuous
 
-import repour.validation
+import repour.server.endpoint.validation as validation
 
 class TestPrimitives(unittest.TestCase):
     def test_nonempty_str(self):
-        self.assertEqual("asd", repour.validation.nonempty_str("asd"))
-        self.assertEqual("asd qwe", repour.validation.nonempty_str("asd qwe"))
-        self.assertEqual(" ", repour.validation.nonempty_str(" "))
+        self.assertEqual("asd", validation.nonempty_str("asd"))
+        self.assertEqual("asd qwe", validation.nonempty_str("asd qwe"))
+        self.assertEqual(" ", validation.nonempty_str(" "))
 
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_str("")
+            validation.nonempty_str("")
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_str(0)
+            validation.nonempty_str(0)
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_str(False)
+            validation.nonempty_str(False)
 
     def test_nonempty_noblank_str(self):
-        self.assertEqual("asd", repour.validation.nonempty_noblank_str("asd"))
+        self.assertEqual("asd", validation.nonempty_noblank_str("asd"))
 
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_noblank_str("")
+            validation.nonempty_noblank_str("")
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_noblank_str("\n")
+            validation.nonempty_noblank_str("\n")
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_noblank_str("asd qwe")
+            validation.nonempty_noblank_str("asd qwe")
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_noblank_str(1)
+            validation.nonempty_noblank_str(1)
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.nonempty_noblank_str(True)
+            validation.nonempty_noblank_str(True)
 
     def test_port_num(self):
-        self.assertEqual(65535, repour.validation.port_num(65535))
+        self.assertEqual(65535, validation.port_num(65535))
 
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.port_num(0)
+            validation.port_num(0)
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.port_num(65536)
+            validation.port_num(65536)
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.port_num("1000")
+            validation.port_num("1000")
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.port_num(False)
+            validation.port_num(False)
 
     def test_name_str(self):
-        self.assertEqual("asd", repour.validation.name_str("asd"))
-        self.assertEqual("ASD", repour.validation.name_str("ASD"))
-        self.assertEqual("123", repour.validation.name_str("123"))
-        self.assertEqual("_", repour.validation.name_str("_"))
-        self.assertEqual("asd-1.5.0", repour.validation.name_str("asd-1.5.0"))
-        self.assertEqual("_ASD-", repour.validation.name_str("_ASD-"))
+        self.assertEqual("asd", validation.name_str("asd"))
+        self.assertEqual("ASD", validation.name_str("ASD"))
+        self.assertEqual("123", validation.name_str("123"))
+        self.assertEqual("_", validation.name_str("_"))
+        self.assertEqual("asd-1.5.0", validation.name_str("asd-1.5.0"))
+        self.assertEqual("_ASD-", validation.name_str("_ASD-"))
 
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str("")
+            validation.name_str("")
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str(" ")
+            validation.name_str(" ")
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str("-asd-1.5.0")
+            validation.name_str("-asd-1.5.0")
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str("asd!1.5.0")
+            validation.name_str("asd!1.5.0")
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str("%")
+            validation.name_str("%")
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str(0)
+            validation.name_str(0)
         with self.assertRaises(voluptuous.MatchInvalid):
-            repour.validation.name_str(False)
+            validation.name_str(False)
 
 class TestAdjust(unittest.TestCase):
     def test_adjust(self):
@@ -72,30 +72,30 @@ class TestAdjust(unittest.TestCase):
             "name": "someproject",
             "ref": "2.2.11.Final",
         }
-        self.assertEqual(valid, repour.validation.adjust(valid))
+        self.assertEqual(valid, validation.adjust(valid))
 
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({})
+            validation.adjust({})
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "name": "someproject",
             })
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "ref": "2.2.11.Final",
             })
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "name": "someproject",
                 "ref": "",
             })
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "name": "",
                 "ref": "2.2.11.Final",
             })
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "name": "someproject",
                 "ref": "2.2.11.Final",
                 "asd": "123",
@@ -109,7 +109,7 @@ class TestAdjust(unittest.TestCase):
                 "url": "http://localhost/asd"
             },
         }
-        self.assertEqual(valid, repour.validation.adjust(valid))
+        self.assertEqual(valid, validation.adjust(valid))
         valid = {
             "name": "someproject",
             "ref": "2.2.11.Final",
@@ -118,7 +118,7 @@ class TestAdjust(unittest.TestCase):
                 "method": "POST",
             },
         }
-        self.assertEqual(valid, repour.validation.adjust(valid))
+        self.assertEqual(valid, validation.adjust(valid))
         valid = {
             "name": "someproject",
             "ref": "2.2.11.Final",
@@ -127,9 +127,9 @@ class TestAdjust(unittest.TestCase):
                 "method": "PUT",
             },
         }
-        self.assertEqual(valid, repour.validation.adjust(valid))
+        self.assertEqual(valid, validation.adjust(valid))
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.adjust({
+            validation.adjust({
                 "name": "someproject",
                 "ref": "2.2.11.Final",
                 "callback": {
@@ -142,9 +142,9 @@ class TestPull(unittest.TestCase):
     def test_pull(self):
         def check_adjust(d):
             d["adjust"] = True
-            self.assertEqual(d, repour.validation.pull(d))
+            self.assertEqual(d, validation.pull(d))
             d["adjust"] = False
-            self.assertEqual(d, repour.validation.pull(d))
+            self.assertEqual(d, validation.pull(d))
 
         valid_scm = {
             "name": "someproject",
@@ -152,15 +152,15 @@ class TestPull(unittest.TestCase):
             "ref": "2.2.11.Final",
             "url": "git://example.com/someproject.git",
         }
-        self.assertEqual(valid_scm, repour.validation.pull(valid_scm))
+        self.assertEqual(valid_scm, validation.pull(valid_scm))
         check_adjust(valid_scm)
 
         valid_scm["type"] = "hg"
-        self.assertEqual(valid_scm, repour.validation.pull(valid_scm))
+        self.assertEqual(valid_scm, validation.pull(valid_scm))
         check_adjust(valid_scm)
 
         del valid_scm["ref"]
-        self.assertEqual(valid_scm, repour.validation.pull(valid_scm))
+        self.assertEqual(valid_scm, validation.pull(valid_scm))
         check_adjust(valid_scm)
 
         valid_archive = {
@@ -168,26 +168,26 @@ class TestPull(unittest.TestCase):
             "type": "archive",
             "url": "http://example.com/someproject.tar.gz",
         }
-        self.assertEqual(valid_archive, repour.validation.pull(valid_archive))
+        self.assertEqual(valid_archive, validation.pull(valid_archive))
         check_adjust(valid_archive)
 
         with self.assertRaises(voluptuous.MultipleInvalid):
             valid_archive["name"] = ""
-            repour.validation.pull(valid_archive)
+            validation.pull(valid_archive)
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.pull({})
+            validation.pull({})
         with self.assertRaises(voluptuous.MultipleInvalid):
-            repour.validation.pull({
+            validation.pull({
                 "name": "someproject",
             })
         with self.assertRaises(voluptuous.MultipleInvalid):
             invalid = valid_scm.copy()
             invalid["asd"] = "asd"
-            repour.validation.pull(invalid)
+            validation.pull(invalid)
         with self.assertRaises(voluptuous.MultipleInvalid):
             invalid = valid_scm.copy()
             invalid["url"] = 123
-            repour.validation.pull(invalid)
+            validation.pull(invalid)
 
     def test_callback(self):
         valid = {
@@ -198,7 +198,7 @@ class TestPull(unittest.TestCase):
                 "url": "http://localhost/asd",
             },
         }
-        self.assertEqual(valid, repour.validation.pull(valid))
+        self.assertEqual(valid, validation.pull(valid))
 
 class TestServerConfig(unittest.TestCase):
     def test_server_config(self):
@@ -226,4 +226,4 @@ class TestServerConfig(unittest.TestCase):
                 },
             },
         }
-        self.assertEqual(valid, repour.validation.server_config(valid))
+        self.assertEqual(valid, validation.server_config(valid))

--- a/test/util.py
+++ b/test/util.py
@@ -77,7 +77,7 @@ def http_write_handler(stream):
     @asyncio.coroutine
     def handler(request):
         resp = aiohttp.web.StreamResponse()
-        resp.start(request)
+        yield from resp.prepare(request)
 
         stream.seek(0)
         while True:


### PR DESCRIPTION
The repour tests haven't been updated with all the changes that have happened in the repour codebase.

This PR attempts to fix all the existing tests to make them pass.

Most of the changes concern changes in moving of code, removal of creation of branches, and some minor changes in the way a function has to be called.