### PR TITLE
Don't use 'git -C' option for tests

### DIFF
--- a/test/__main__.py
+++ b/test/__main__.py
@@ -9,4 +9,7 @@ if __name__ == "__main__":
     )
 
     runner = unittest.TextTestRunner()
-    sys.exit(runner.run(tests).failures != 0)
+    results = runner.run(tests)
+
+    # results.failures and results.errors return a list
+    sys.exit(len(results.failures) + len(results.errors))

--- a/test/test_adjust.py
+++ b/test/test_adjust.py
@@ -21,8 +21,8 @@ class TestAdjust(unittest.TestCase):
         with open(os.path.join(cls.origin_git.readwrite, "asd.txt"), "w") as f:
             f.write("Hello")
 
-        util.quiet_check_call(["git", "-C", cls.origin_git.readwrite, "add", "-A"])
-        util.quiet_check_call(["git", "-C", cls.origin_git.readwrite, "commit", "-m", "Pull"])
+        util.quiet_check_call(["git", "add", "-A"], cwd=cls.origin_git.readwrite)
+        util.quiet_check_call(["git", "commit", "-m", "Pull"], cwd=cls.origin_git.readwrite)
 
         # Convert to bare
         os.remove(os.path.join(cls.origin_git.readwrite, "asd.txt"))
@@ -30,7 +30,7 @@ class TestAdjust(unittest.TestCase):
         for fn in os.listdir(git_dir):
             shutil.move(os.path.join(git_dir, fn), cls.origin_git.readwrite)
         os.rmdir(git_dir)
-        util.quiet_check_call(["git", "-C", cls.origin_git.readwrite, "config", "--bool", "core.bare", "true"])
+        util.quiet_check_call(["git", "config", "--bool", "core.bare", "true"], cwd=cls.origin_git.readwrite)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/test_asgit.py
+++ b/test/test_asgit.py
@@ -15,7 +15,7 @@ class TestCommon(unittest.TestCase):
     def test_setup_commiter(self):
         with util.TemporaryGitDirectory() as repo:
             loop.run_until_complete(repour.asgit.setup_commiter(expect_ok, repo))
-            out = subprocess.check_output(["git", "-C", repo, "config", "--local", "-l"])
+            out = subprocess.check_output(["git", "config", "--local", "-l"], cwd=repo)
 
         self.assertIn(b"user.name=", out)
         self.assertIn(b"user.email=", out)
@@ -24,9 +24,9 @@ class TestCommon(unittest.TestCase):
         with util.TemporaryGitDirectory() as repo:
             with open(os.path.join(repo, "asd.txt"), "w") as f:
                 f.write("Hello")
-            util.quiet_check_call(["git", "-C", repo, "add", "-A"])
+            util.quiet_check_call(["git", "add", "-A"], cwd=repo)
             loop.run_until_complete(repour.asgit.fixed_date_commit(expect_ok, repo, "Test"))
-            out = subprocess.check_output(["git", "-C", repo, "log", "-1", "--pretty=fuller"])
+            out = subprocess.check_output(["git", "log", "-1", "--pretty=fuller"], cwd=repo)
 
         self.assertIn(b"AuthorDate: Thu Jan 1 00:00:00 1970 +0000", out)
         self.assertIn(b"CommitDate: Thu Jan 1 00:00:00 1970 +0000", out)
@@ -36,21 +36,21 @@ class TestCommon(unittest.TestCase):
             with open(os.path.join(repo, "asd.txt"), "w") as f:
                 f.write("Hello")
             loop.run_until_complete(repour.asgit.prepare_new_branch(expect_ok, repo, "pull-1234567890", orphan=True))
-            util.quiet_check_call(["git", "-C", repo, "commit", "-m", "Test"])
+            util.quiet_check_call(["git", "commit", "-m", "Test"], cwd=repo)
 
             with open(os.path.join(repo, "asd.txt"), "w") as f:
                 f.write("Hello Hello")
             loop.run_until_complete(repour.asgit.prepare_new_branch(expect_ok, repo, "adjust-1234567890"))
-            util.quiet_check_call(["git", "-C", repo, "commit", "-m", "Test"])
+            util.quiet_check_call(["git", "commit", "-m", "Test"], cwd=repo)
 
     def test_annotated_tag(self):
         with util.TemporaryGitDirectory() as repo:
             with open(os.path.join(repo, "asd.txt"), "w") as f:
                 f.write("Hello")
-            util.quiet_check_call(["git", "-C", repo, "add", "-A"])
-            util.quiet_check_call(["git", "-C", repo, "commit", "-m", "Test"])
+            util.quiet_check_call(["git", "add", "-A"], cwd=repo)
+            util.quiet_check_call(["git", "commit", "-m", "Test"], cwd=repo)
             loop.run_until_complete(repour.asgit.annotated_tag(expect_ok, repo, "pull-1234567890-root", "Annotation"))
-            out = subprocess.check_output(["git", "-C", repo, "tag", "-l", "-n"])
+            out = subprocess.check_output(["git", "tag", "-l", "-n"], cwd=repo)
 
         self.assertIn(b"pull-1234567890-root Annotation", out)
 
@@ -59,13 +59,13 @@ class TestCommon(unittest.TestCase):
             with util.TemporaryGitDirectory(origin=remote) as repo:
                 with open(os.path.join(repo, "asd.txt"), "w") as f:
                     f.write("Goodbye")
-                util.quiet_check_call(["git", "-C", repo, "add", "-A"])
-                util.quiet_check_call(["git", "-C", repo, "commit", "-m", "Test Commit"])
-                util.quiet_check_call(["git", "-C", repo, "tag", "test-tag"])
+                util.quiet_check_call(["git", "add", "-A"], cwd=repo)
+                util.quiet_check_call(["git", "commit", "-m", "Test Commit"], cwd=repo)
+                util.quiet_check_call(["git", "tag", "test-tag"], cwd=repo)
 
                 loop.run_until_complete(repour.asgit.push_with_tags(expect_ok, repo, "master"))
 
-                remote_tags = subprocess.check_output(["git", "-C", repo, "tag", "-l", "-n"])
+                remote_tags = subprocess.check_output(["git", "tag", "-l", "-n"], cwd=repo)
 
         self.assertIn(b"test-tag        Test Commit", remote_tags)
 

--- a/test/test_pull.py
+++ b/test/test_pull.py
@@ -27,7 +27,7 @@ class TestToInternal(unittest.TestCase):
                     origin_type="git",
                 ))
                 self.assertIsInstance(d, dict)
-            out = subprocess.check_output(["git", "-C", remote.readwrite, "tag", "-l", "-n5"])
+            out = subprocess.check_output(["git", "tag", "-l", "-n5"], cwd=remote.readwrite)
             self.assertIn(b"""Origin: git://example.com/repo
     Reference: v1.0
     Type: git""", out)
@@ -95,9 +95,9 @@ class TestProcessSourceTree(unittest.TestCase):
                 self.assertRegex(d["pull"]["tag"], r'^repour-[0-9a-f]+$')
 
                 # Verify adjust commit is child of pull commit
-                out = subprocess.check_output(["git", "-C", remote.readwrite, "rev-list", "--parents", "-n1", d["tag"]])
+                out = subprocess.check_output(["git", "rev-list", "--parents", "-n1", d["tag"]], cwd=remote.readwrite)
                 adjust_commit, adjust_parent = out.decode("utf-8").strip().split(" ")
-                out = subprocess.check_output(["git", "-C", remote.readwrite, "rev-list", "-n1", d["pull"]["tag"]])
+                out = subprocess.check_output(["git", "rev-list", "-n1", d["pull"]["tag"]], cwd=remote.readwrite)
                 pull_commit = out.decode("utf-8").strip()
 
                 self.assertEqual(adjust_parent, pull_commit)
@@ -144,8 +144,8 @@ class TestPull(unittest.TestCase):
         with open(os.path.join(cls.origin_git, "asd.txt"), "w") as f:
             f.write("Origin")
 
-        util.quiet_check_call(["git", "-C", cls.origin_git, "add", "-A"])
-        util.quiet_check_call(["git", "-C", cls.origin_git, "commit", "-m", "Some origin commit"])
+        util.quiet_check_call(["git", "add", "-A"], cwd=cls.origin_git)
+        util.quiet_check_call(["git", "commit", "-m", "Some origin commit"], cwd=cls.origin_git)
 
         cls.origin_git = "file://" + cls.origin_git
 

--- a/test/util.py
+++ b/test/util.py
@@ -24,12 +24,12 @@ class TemporaryGitDirectory(tempfile.TemporaryDirectory):
             quiet_check_call(cmd)
 
             if self.origin is not None:
-                quiet_check_call(["git", "-C", self.name, "remote", "add", "origin", "file://" + self.origin])
+                quiet_check_call(["git", "remote", "add", "origin", "file://" + self.origin], cwd=self.name)
         else:
             quiet_check_call(["git", "clone", "--branch", self.ref, "--depth", "1", "--", "file://" + self.origin, self.name])
 
-        quiet_check_call(["git", "-C", self.name, "config", "--local", "user.name", "Repour"])
-        quiet_check_call(["git", "-C", self.name, "config", "--local", "user.email", "<>"])
+        quiet_check_call(["git", "config", "--local", "user.name", "Repour"], cwd=self.name)
+        quiet_check_call(["git", "config", "--local", "user.email", "<>"], cwd=self.name)
 
         if self.ro_url is not None:
             return repour.repo.RepoUrls(readonly=self.ro_url, readwrite=self.name)
@@ -53,8 +53,11 @@ class TemporaryHgDirectory(tempfile.TemporaryDirectory):
 
         return self.name
 
-def quiet_check_call(cmd):
-    return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+def quiet_check_call(cmd, cwd=None):
+    if cwd is None:
+        return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        return subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=cwd)
 
 def setup_http(cls, loop, routes):
     app = aiohttp.web.Application(loop=loop)


### PR DESCRIPTION
We don't want to use 'git -C' because that configuration is not
available in the Git version we are using on RHEL 7 / CentOS 7