### PR TITLE
[NCL-2981] Adapt /adjust to have syncing feature

### DIFF
--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -57,6 +57,14 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def remove_remote(dir, name):
+        yield from expect_ok(
+            cmd=["git", "remote", "remove", name],
+            cwd=dir,
+            desc="Could not remove remote {} with git.".format(name),
+        )
+
+    @asyncio.coroutine
     def add_remote(dir, name, url):
         yield from expect_ok(
             cmd=["git", "remote", "add", name, url, "--"],
@@ -314,6 +322,7 @@ def git_provider():
     return {
         "version": version,
         "init": init,
+        "remove_remote": remove_remote,
         "add_remote": add_remote,
         "add_branch": add_branch,
         "delete_branch": delete_branch,

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -47,6 +47,8 @@ adjust_raw = {
     "name": name_str,
     "ref": nonempty_str,
     Optional("adjustParameters"): All(dict),
+    Optional("originRepoUrl"): nonempty_str,
+    Optional("sync"): bool,
     Optional("callback"): callback_raw,
 }
 


### PR DESCRIPTION
That sync feature is only enabled if the keys:

- originRepoUrl *and*
- sync (with value True)

are sent to the `/adjust` endpoint. Otherwise the sync won't happen and
`/adjust` will behave as before.

While I did a similar commit with adding the `/cloneadjust` endpoint, I
now realize that using the `/cloneadjust` endpoint on the Maitai process
is awkward because, based on the 'sync' being true or false, I'd have to
call `/cloneadjst` or `/adjust` endpoint respectively on the Maitai
side.

I believe it's better to add the feature to the `/adjust` endpoint so
that it requires minimum changes on the Maitai side, while keeping
`/adjust` backwards compatible.

A future commit will remove the `/cloneadjust` endpoint.