### PR TITLE
[NCL-3117] Unify syncing behaviour for /clone and /adjust

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -6,6 +6,7 @@ from . import pme_provider
 from . import process_provider
 from .. import asgit
 from .. import asutil
+from .. import clone
 from .. import exception
 from ..config import config
 from ..scm import git_provider
@@ -56,22 +57,7 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
     yield from git["add_remote"](work_dir, "origin", asutil.add_username_url(internal_repo_url.readwrite, git_user))  # Add target remote
 
     ref = adjustspec["ref"]
-
-    isRefBranch = yield from git["is_branch"](work_dir, ref)  # if ref is a branch, we don't have to create one
-    isRefTag = yield from git["is_tag"](work_dir, ref)
-
-    if isRefBranch:
-        yield from git["push"](work_dir, "origin", ref)  # push it to the remote
-    elif isRefTag:
-        yield from git["push_with_tags"](work_dir, ref, remote="origin")
-    else:
-        # Case if ref is a particular SHA
-        # We can't really push a particular hash to the target repository
-        # unless it is in a branch. We have to create the branch to be able
-        # to push the SHA
-        branch = "branch-" + ref
-        yield from git["add_branch"](work_dir, branch)
-        yield from git["push"](work_dir, "origin", branch)  # push it to the remote
+    yield from clone.push_sync_changes(work_dir, ref, "origin")
 
 @asyncio.coroutine
 def adjust(adjustspec, repo_provider):

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -57,6 +57,14 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def add_tag(dir, name):
+        yield from expect_ok(
+            cmd=["git", "tag", name],
+            cwd=dir,
+            desc="Could not add tag {} with git.".format(name),
+        )
+
+    @asyncio.coroutine
     def remove_remote(dir, name):
         yield from expect_ok(
             cmd=["git", "remote", "remove", name],
@@ -105,23 +113,23 @@ def git_provider():
         )
 
     @asyncio.coroutine
-    def push_force(dir, remote, branch):  # Warning! --force
-        yield from push(dir, remote, branch, force=True)
+    def push_force(dir, remote, branch_or_tag):  # Warning! --force
+        yield from push(dir, remote, branch_or_tag, force=True)
 
     @asyncio.coroutine
-    def push(dir, remote, branch, force=False):
+    def push(dir, remote, branch_or_tag, force=False):
 
         cmd = ["git", "push"]
 
         if force:
             cmd.append("--force")
 
-        cmd.extend([remote, branch, "--"])
+        cmd.extend([remote, branch_or_tag, "--"])
 
         yield from expect_ok(
             cmd=cmd,
             cwd=dir,
-            desc="Could not push branch '{}' to remote '{}' with git".format(branch, remote),
+            desc="Could not push branch or tag '{}' to remote '{}' with git".format(branch_or_tag, remote),
         )
 
     @asyncio.coroutine  # TODO merge with above
@@ -322,6 +330,7 @@ def git_provider():
     return {
         "version": version,
         "init": init,
+        "add_tag": add_tag,
         "remove_remote": remove_remote,
         "add_remote": add_remote,
         "add_branch": add_branch,


### PR DESCRIPTION
The previous behaviour of `/clone` was to create a branch if the ref
wasn't a branch. The original idea was to allow the user to manually
apply additional changes to the branch if required.

However, it turns out we never really needed that feature. This commit
removes this behaviour.

For both /clone and /adjust (with auto-sync enabled), if the ref is a:

- tag => tag gets synced with internal repo
- branch => branch gets synced with internal repo
- SHA => SHA gets synced with internal repo (via indirect creation of a
         tag with format 'repour-sync-ref' to make this possible)