### PR TITLE
[NCL-3071] Allow syncing all the repository

### DIFF
--- a/repour/clone.py
+++ b/repour/clone.py
@@ -64,16 +64,21 @@ def clone_git(clonespec):
         c = yield from config.get_configuration()
         git_user = c.get("git_username")
 
-        yield from git["clone"](clone_dir, asutil.add_username_url(clonespec["originRepoUrl"], git_user))  # Clone origin
-        yield from git["checkout"](clone_dir, clonespec["ref"])  # Checkout ref
-        yield from git["add_remote"](clone_dir, "target", clonespec["targetRepoUrl"])  # Add target remote
+        if "ref" in clonespec:
+            yield from git["clone"](clone_dir, clonespec["originRepoUrl"])  # Clone origin
+            yield from git["checkout"](clone_dir, clonespec["ref"])  # Checkout ref
+            yield from git["add_remote"](clone_dir, "target", asutil.add_username_url(clonespec["targetRepoUrl"], git_user))  # Add target remote
 
-        ref = clonespec["ref"]
-        yield from push_sync_changes(clone_dir, ref, "target")
+            ref = clonespec["ref"]
+            yield from push_sync_changes(clone_dir, ref, "target")
+        else:
+            # Sync everything if ref not specified
+            yield from git["clone_mirror"](clone_dir, clonespec["originRepoUrl"])  # Clone origin
+            yield from git["add_remote"](clone_dir, "target", asutil.add_username_url(clonespec["targetRepoUrl"], git_user))  # Add target remote
+            yield from git["push_mirror"](clone_dir, "target")
 
         return clonespec
 
 scm_types = {
     "git": clone_git,
 }
-

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -57,6 +57,13 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def clone_mirror(dir, url):
+        yield from expect_ok(
+            cmd=["git", "clone", "--mirror", "--", url, dir],
+            desc="Could not clone mirror {} with git.".format(url),
+        )
+
+    @asyncio.coroutine
     def add_tag(dir, name):
         yield from expect_ok(
             cmd=["git", "tag", name],
@@ -130,6 +137,19 @@ def git_provider():
             cmd=cmd,
             cwd=dir,
             desc="Could not push branch or tag '{}' to remote '{}' with git".format(branch_or_tag, remote),
+        )
+
+    @asyncio.coroutine
+    def push_mirror(dir, remote):
+
+        cmd = ["git", "push", "--mirror"]
+
+        cmd.extend([remote, "--"])
+
+        yield from expect_ok(
+            cmd=cmd,
+            cwd=dir,
+            desc="Could not push mirror to remote '{}' with git".format(remote),
         )
 
     @asyncio.coroutine  # TODO merge with above
@@ -337,10 +357,12 @@ def git_provider():
         "delete_branch": delete_branch,
         "push_force": push_force,
         "push": push,
+        "push_mirror": push_mirror,
         "push_with_tags": push_with_tags,
         "is_branch": is_branch,
         "is_tag": is_tag,
         "clone": clone,
+        "clone_mirror": clone_mirror,
         "clone_deep": clone_deep,
         "checkout": checkout,
         "clone_checkout_branch_tag_shallow": clone_checkout_branch_tag_shallow,

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -117,7 +117,7 @@ pull_modeb = Schema(
 clone_raw = {
     #"name": name_str,
     "type": "git", # only git supported for now
-    "ref": nonempty_str,
+    Optional("ref"): nonempty_str,
     "originRepoUrl": Url(),
     "targetRepoUrl": Url(),
     Optional("callback"): callback_raw,


### PR DESCRIPTION
This applies to the `/clone` endpoint. If the `ref` is not specified,
the default behaviour is to clone the origin url to the target url