### PR TITLE
[NCL-2889] Use correct time in repour commits

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -150,6 +150,7 @@ def commit_adjustments(repo_dir, repo_url, original_ref, adjust_type, force_cont
 Adjust Type: {adjust_type}
 """.format(**locals()),
         no_change_ok=True,
-        force_continue_on_no_changes=force_continue_on_no_changes
+        force_continue_on_no_changes=force_continue_on_no_changes,
+        real_commit_time=True,
     )
     return d

--- a/repour/pull.py
+++ b/repour/pull.py
@@ -63,6 +63,7 @@ def process_source_tree(pullspec, repo_provider, adjust_provider, repo_dir, orig
             repo_url=internal_repo_url,
             original_ref=pull_internal["tag"],
             adjust_type=adjust_type,
+            force_continue_on_no_changes=True,
         )
     else:
         adjust_internal = None

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -247,14 +247,17 @@ def git_provider():
         )
 
     @asyncio.coroutine
-    def commit(dir, commit_message, commit_date):
+    def commit(dir, commit_message, commit_date=None):
+
+        if commit_date:
+            env = {"GIT_AUTHOR_DATE": commit_date, "GIT_COMMITTER_DATE": commit_date}
+        else:
+            env = {}
+
         yield from expect_ok(
             cmd=["git", "commit", "-m", commit_message],
             desc="Could not commit files with git",
-            env={
-                "GIT_AUTHOR_DATE": commit_date,
-                "GIT_COMMITTER_DATE": commit_date,
-            },
+            env=env,
             cwd=dir
         )
 
@@ -305,6 +308,62 @@ def git_provider():
                 pass # ok
             else:
                 raise e
+
+    @asyncio.coroutine
+    def write_tree(dir):
+        """
+        Get the tree SHA from current index
+        """
+        tree_sha = yield from expect_ok(
+                cmd=["git", "write-tree"],
+                desc="Couldn't get the commit tree with git",
+                stdout="text",
+                cwd=dir
+        )
+        return tree_sha.strip()
+
+    @asyncio.coroutine
+    def get_tag_from_tree_sha(dir, tree_sha):
+        """
+        Return the tag for a particular tree SHA
+        Return None if no such tag exists
+        """
+        def get_tag_name(temp_tags):
+            """
+            temp_tags is in format: 'tag: <tag1>, <tag2>, <tag3> ...'
+            return first tag (aka tag1)
+            """
+            if 'tag:' in temp_tags:
+                comma_delimited_tags = re.sub(r"^.*tag:", "", temp_tags.strip()).strip()
+                return comma_delimited_tags.split(",")[0]
+            else:
+                return None
+
+        try:
+            data = yield from expect_ok(
+                # separate the tree SHA and the tag information with '::'
+                # output is <tree_sha>::tag: <tag1>, <tag2>, ...
+                cmd=["git", "--no-pager", "log", "--tags", "--no-walk", '--pretty="%T::%D"'],
+                desc="Couldn't get the tree hash / tag relationship via git log",
+                stdout="lines",
+                cwd=dir
+            )
+            # Each line contains information about a tree sha, and the tag(s) pointing to it indirectly
+            for item in data:
+                # For some reason the text from 'expect_ok' are in quotes. Remove it
+                item = item.replace('"', '')
+
+                temp_tree_sha, temp_tags = item.split('::')
+
+                if temp_tree_sha == tree_sha:
+                    return get_tag_name(temp_tags)
+            else:
+                return None
+
+        except exception.CommandError as e:
+            # No commits yet in the tag
+            if "does not have any commits yet" in e.stderr:
+                return None
 
 
     @asyncio.coroutine
@@ -401,6 +460,8 @@ def git_provider():
         "create_branch_checkout": create_branch_checkout,
         "add_all": add_all,
         "tag_annotated": tag_annotated,
+        "write_tree": write_tree,
+        "get_tag_from_tree_sha": get_tag_from_tree_sha,
         "disable_bare_repository": disable_bare_repository,
         "reset_hard": reset_hard
     }

--- a/test/test_pull.py
+++ b/test/test_pull.py
@@ -131,7 +131,6 @@ class TestProcessSourceTree(unittest.TestCase):
                     origin_type="git",
                     origin_ref="v1.0",
                 ))
-
                 self.assertRegex(d["tag"], r'^repour-[0-9a-f]+$')
 
 class TestPull(unittest.TestCase):

--- a/test/util.py
+++ b/test/util.py
@@ -26,7 +26,7 @@ class TemporaryGitDirectory(tempfile.TemporaryDirectory):
             if self.origin is not None:
                 quiet_check_call(["git", "remote", "add", "origin", "file://" + self.origin], cwd=self.name)
         else:
-            quiet_check_call(["git", "clone", "--branch", self.ref, "--depth", "1", "--", "file://" + self.origin, self.name])
+            quiet_check_call(["git", "clone", "--branch", self.ref, "--", "file://" + self.origin, self.name])
 
         quiet_check_call(["git", "config", "--local", "user.name", "Repour"], cwd=self.name)
         quiet_check_call(["git", "config", "--local", "user.email", "<>"], cwd=self.name)


### PR DESCRIPTION
Before, we used a fixed date for all of the commits that repour did.
This was done to generate the same commit SHA if a previous commit
containing the same repository directory contents existed.

This was done so that we don't create *new* commits every time repour
runs the adjust phase, if the same changes are applied to the source
repository as before.

(The commit SHA is built from the tree SHA, parent commit SHA, date,
 author, commit message etc. We tried to keep the parent commit SHA,
 date, author, commit message constant in Repour)

By focusing on the tree SHA instead of the commit SHA, we are now able
to use the real date in our commits, while preventing duplication of
commits for each adjust phase which produces the same changes.

This commit attempts to use a different approach: since we only really
care about the content changed in the source repository after the
adjust phase is done, we'll generate the tree SHA with the changes from
the adjust phase, and try to figure out if the tree SHA is associated to
a tag.

- If a tag is found: that means that there were a previous adjust commit
  that was performed before with the tag found also created. We can then
  return the tag name.

  The author thinks that the process above to find if a tree SHA maps a
  tag should be fast given that a project tends to not have many tags (<
  100), so the search space is greatly reduced. But even on tests
  performed, git generated a map of the tree SHA to commit SHA for
  ~58,000 commit SHAs relatively fast (~ 1.5 seconds) (kubernetes
  project).

  This was performed inside the repour Openshift pod:
```
sh-4.2# git clone https://github.com/kubernetes/kubernetes
Cloning into 'kubernetes'...
remote: Counting objects: 599177, done.
remote: Compressing objects: 100% (52/52), done.
remote: Total 599177 (delta 25), reused 23 (delta 20), pack-reused 599105
Receiving objects: 100% (599177/599177), 454.20 MiB | 18.90 MiB/s, done.
Resolving deltas: 100% (406695/406695), done.
Checking out files: 100% (14839/14839), done.

sh-4.2# cd kubernetes/

sh-4.2# time git --no-pager log --all --pretty="format:%T::%H" > haha

real	0m1.575s
user	0m1.386s
sys	0m0.105s
```

- If the tag is not found: there are no previous adjust commit, so we
  should create the commit, tag, and push it to the internal repository.
  The tag information is returned. The commit performed will now use the
  *correct* date, and not a fixed date.