### PR TITLE
[NCL-3503] endpoint adjusted to accept new param

### DIFF
--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -12,7 +12,8 @@ from xml.dom import minidom
 logger = logging.getLogger(__name__)
 
 
-def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_logs=False):
+# TODO: NCL-3503: Finish implementation once the other components are figured out
+def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_logs=False, specific_indy_group=None, timestamp=None):
     @asyncio.coroutine
     def get_result_data(work_dir):
         raw_result_data = "{}"

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -29,5 +29,6 @@
       "user.email": "<>"
     }
   },
-  "git_username": ""
+  "git_username": "",
+  "temp_build_indy_group": ""
 }

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -52,6 +52,8 @@ adjust_raw = {
     Optional("originRepoUrl"): nonempty_str,
     Optional("sync"): bool,
     Optional("callback"): callback_raw,
+    Optional("tempBuild"): bool,
+    Optional("tempBuildTimestamp"): nonempty_str,
 }
 
 adjust = Schema(


### PR DESCRIPTION
The `/adjust` endpoint is adjust to now also accept the parameters:

- tempBuild [optional] (with as value a boolean)
- tempBuildTimestamp [optional] (with as value a string)

For `tempBuildTimestamp` to have any effect, `tempBuild` key must be
specified and must have a value of 'true'.

If `tempBuild` is set to true, PME will use a specific Indy group for
PME alignmnent.

The new parameter to define in the repour config is:

```
{
    ...
    "temp_build_indy_group": "<indy group to use>",
    ...
}
```

This commit allows further work to be done on the Maitai side. When the
specifics on how PME will deal with temp build and temp build timestamp
is known, a further commit will be done to use the new parameters.