### PR TITLE
[NCL-2467] Add cancel support

### DIFF
--- a/repour/server/endpoint/cancel.py
+++ b/repour/server/endpoint/cancel.py
@@ -6,11 +6,60 @@ from aiohttp import web
 
 logger = logging.getLogger(__name__)
 
-# Mock cancel endpoint
-
 @asyncio.coroutine
 def handle_cancel(request):
+
+    task_id_to_cancel = request.match_info['task_id']
+    logger.info("Cancel request obtained: " + str(task_id_to_cancel))
+
+    if not task_id_to_cancel:
+        response = yield from bad_response("Task id is not provided")
+        return response
+
+    all_tasks = asyncio.Task.all_tasks()
+
+    for task in all_tasks:
+        task_id_of_task = getattr(task, "task_id", None)
+
+        if task_id_of_task == task_id_to_cancel:
+            task.cancel()
+            response = yield from success_response("Task cancelled: " + str(task_id_to_cancel))
+            return response
+    else:
+        # if we are here, the task id wasn't found
+        response = yield from bad_response("task id " + str(task_id_to_cancel) + " not found!")
+        return response
+
+
+@asyncio.coroutine
+def bad_response(error_message):
+    logger.warn(error_message)
     response = web.Response(
-        status=200
+        status=400,
+        content_type="application/json",
+        text=json.dumps(
+            obj=[{
+                "error_message": error_message,
+            }],
+            ensure_ascii=False,
+        ),
+    )
+    return response
+
+
+@asyncio.coroutine
+def success_response(message):
+
+    logger.info(message)
+
+    response = web.Response(
+        status=200,
+        content_type="application/json",
+        text=json.dumps(
+            obj=[{
+                "message": message,
+            }],
+            ensure_ascii=False,
+        ),
     )
     return response

--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -121,6 +121,11 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):
         else:
             callback_mode = True
 
+        # Set the task_id if provided in the request
+        task_id = spec.get('taskId', None)
+        if task_id:
+            asyncio.Task.current_task().task_id = task_id
+
         @asyncio.coroutine
         def do_call():
             try:

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -54,6 +54,7 @@ adjust_raw = {
     Optional("callback"): callback_raw,
     Optional("tempBuild"): bool,
     Optional("tempBuildTimestamp"): null_or_str,
+    Optional("taskId"): null_or_str,
 }
 
 adjust = Schema(

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -49,7 +49,7 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
     app.router.add_route("POST", "/pull", pull_source)
     app.router.add_route("POST", "/adjust", adjust_source)
     app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))
-    app.router.add_route("POST", "/cancel", cancel.handle_cancel)
+    app.router.add_route("POST", "/cancel/{task_id}", cancel.handle_cancel)
     app.router.add_route("GET", "/callback/{callback_id}", ws.handle_socket)
 
     logger.debug("Creating asyncio server")


### PR DESCRIPTION
The way to use cancel operation is by using the endpoint:

```
POST /cancel/{task_id}
```

The task id is specified from the original request, and is only
supported for the `/adjust` endpoint for now.

The request should send:

```
POST /adjust
{
    ...
    "taskId": "1234"
}
```