### PR TITLE
[NCL-2167] Add informational endpoint in Repour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.log
 /config.yaml
+.idea/

--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -1,0 +1,39 @@
+# Naming convention
+
+Our naming convention is as follows:
+```
+<major>.<minor>.<micro>.<qualifier>
+```
+
+
+# Branching
+
+All of our development occurs in the master branch. Once our features are
+mature enough, we create a maintenance branch with the format
+'pnc-<major>.<minor>.x'. When this is done, the repour version in the master
+branch in file `repour/__init__.py` should be bumped to the next major/minor
+release.
+
+
+# Release Instructions
+When we are ready to release Repour, the following instructions have to be
+followed:
+
+1. Update the file `repour/__init__.py` inside our git maintenance branch for
+   the version. The qualifier should be set to 'FINAL' and not 'SNAPSHOT'.
+
+2. Commit the changes and push to upstream git repository
+
+3. Create a tag with format 'pnc-<major>.<minor>.<micro>' and push to upstream
+   git repository
+
+4. Change the file `repour/__init__.py` again to increase the micro version by
+   one, and change the qualifier to 'SNAPSHOT'. Don't forget to commit and push
+   those changes
+
+
+# Version
+When we do a release, the version changes from qualifier 'SNAPSHOT' to 'FINAL'
+
+While developing for the next version, the version qualifier should be
+'SNAPSHOT'

--- a/repour/__init__.py
+++ b/repour/__init__.py
@@ -1,2 +1,2 @@
-version = "0.11.0"
+version = "1.3.0.SNAPSHOT"
 __version__ = version

--- a/repour/auth/auth.py
+++ b/repour/auth/auth.py
@@ -35,6 +35,11 @@ def get_oauth2_jwt_handler(app, next_handler):
             response = yield from next_handler(request)
             return response
 
+        if request.path == "/":
+            # we don't authenticate for request to '/'. We'll show relevant repour information there
+            response = yield from next_handler(request)
+            return response
+
         auth_header_value = request.headers.get('Authorization', None)
         prefix_length = len('Bearer ')
 

--- a/repour/server/endpoint/info.py
+++ b/repour/server/endpoint/info.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+import repour
+import sys
+from aiohttp import web
+from ...scm import git_provider
+from ... import exception
+
+
+@asyncio.coroutine
+def handle_request(request):
+    version = repour.__version__
+    path_name = os.path.dirname(sys.argv[0])
+    try:
+        git_sha = yield from git_provider.git_provider()["rev_parse"](path_name)
+    except exception.CommandError:
+        git_sha = "Unknown"
+
+    html_text = """
+    <h1>Repour Information</h1>
+    <ul>
+        <li><strong>Repour Version</strong> {}</li>
+        <li><strong>Commit Hash</strong> {}</li>
+    </ul>
+    """
+
+    html_text = html_text.format(version, git_sha)
+    return web.Response(text='' + html_text, content_type="text/html")
+
+

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -5,6 +5,7 @@ from aiohttp import web
 
 from .endpoint import cancel
 from .endpoint import endpoint
+from .endpoint import info
 from .endpoint import ws
 from ..adjust import adjust
 from .. import clone
@@ -46,6 +47,7 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
         adjust_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.adjust, adjust.adjust, repour_url)
 
     logger.debug("Setting up handlers")
+    app.router.add_route("GET", "/", info.handle_request)
     app.router.add_route("POST", "/pull", pull_source)
     app.router.add_route("POST", "/adjust", adjust_source)
     app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))


### PR DESCRIPTION
This PR adds support for an informational endpoint in Repour when accessing repour on '/'.

To do so, I deactivated the authentication on the '/' endpoint only so that anyone could access it.

The informational endpoint shows the Repour version (as defined in `repour/__init__.py`) and the Git SHA, if the `.git` folder is in the root folder of the application.

Instructions on what to update during a release is also now provided.
  
![repour_information](https://user-images.githubusercontent.com/630746/34585611-774d7004-f16e-11e7-8004-365d34cb6771.png)
