### PR TITLE
[NCL-3601][master] Correctly process non top-level pom.xml

### DIFF
--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -65,9 +65,21 @@ def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_log
 
     @asyncio.coroutine
     def get_extra_parameters(extra_adjust_parameters):
+        """
+        Get the extra PME parameters from PNC
+        If the PME parameters contain '--file=<folder>/pom.xml', then extract that folder
+        and remove that --file option from the list of extra params.
+        In PME 2.11 and PME 2.12, there is a bug where that option causes the file target/pom-manip-ext-result.json
+        to be badly generated. Fixed in PME 2.13+
+        See: PRODTASKS-361
+        Returns: tuple<list<string>, string>: list of params(minus the --file option), and folder where to run PME
+        If '--file' option not used, the folder will be an empty string
+        """
+        subfolder = ''
+
         paramsString = extra_adjust_parameters.get("CUSTOM_PME_PARAMETERS", None)
         if paramsString is None:
-            return []
+            return [], subfolder
         else:
             params = shlex.split(paramsString)
             for p in params:
@@ -75,7 +87,12 @@ def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_log
                     desc = ('Parameters that do not start with dash "-" are not allowed. '
                             + 'Found "{p}" in "{params}".'.format(**locals()))
                     raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
-            return params
+                if p.startswith("--file"):
+                    subfolder = p.replace("--file=", "").replace("pom.xml", "")
+
+            params_without_file_option = [p for p in params if not p.startswith("--file=")]
+
+            return params_without_file_option, subfolder
 
     @asyncio.coroutine
     def adjust(repo_dir, extra_adjust_parameters, adjust_result):
@@ -88,10 +105,15 @@ def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_log
         if specific_indy_group:
             temp_build_parameters.append("-DrestRepositoryGroup=" + specific_indy_group)
 
+        extra_parameters, subfolder = yield from get_extra_parameters(extra_adjust_parameters)
+
+        # readjust the repo_dir to run PME from the folder where the root pom.xml is located
+        # See: PRODTASKS-361
+        repo_dir = os.path.join(repo_dir, subfolder)
+
         cmd = ["java", "-jar", pme_jar_path] \
-              + pme_parameters \
-              + temp_build_parameters \
-              + (yield from get_extra_parameters(extra_adjust_parameters))
+              + pme_parameters + temp_build_parameters + extra_parameters
+
         logger.info('Executing "' + execution_name + '" using "pme" adjust provider '
                     + '(delegating to "process" provider). Command is "{cmd}".'.format(**locals()))
         res = yield from process_provider.get_process_provider(execution_name,


### PR DESCRIPTION
There are some git repositories where the root pom.xml is not located in
the root location of the repository, but rather in a folder.

```
<folder>/pom.xml
```

PME allows you to specify the `--file=<folder>/pom.xml` param to be
able to run PME from the root of the git repository.

However, when PME is finished, repour tries to read the file
`target/pom-manip-ext-result.json` from the root git repository, instead
of from `<folder>/target/pom-manip-ext-result.json`

So we can fix this issue by either:

- change directory to the 'folder' in the '--file' param, and remove
   the '--file' param in the list of PME parameters. Then run PME from
   the 'folder' to replicate what we do

- Not remove the '--file' param in hte list of PME parameters, and use
  the 'folder' to properly grab the pom-manip-ext-result.json.

While the second option is much simpler, this commit implements the
first option. This is because of PME 2.11 and 2.12 suffering from a bug
when using the '--file' param (See PRODTASKS-361). With that param,
the generated pom-manip-ext-result.json has null as values for all its
keys.

```
{
    "VersioningState": {
        "executionRootModified":{
            "groupId":null,
            "artifactId":null,
            "version":null
        }
    }
}
```

With the first option, we avoid this PME bug also.