### PR TITLE
Push existing tag name for /adjust

### DIFF
--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -103,6 +103,11 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
                                               operation_name, operation_description,
                                               no_change_ok, force_continue_on_no_changes,
                                               real_commit_time)
+    else:
+        # If tag name already exists, make sure it's already present in upstream
+        # This happens if we are doing /adjust, with pre-sync enabled.
+        # The external repo might have the tag, but not the internal repo
+        yield from push_with_tags(expect_ok, repo_dir, tag_name)
 
     if tag_name is None:
         return None


### PR DESCRIPTION
If the tag name after the adjust alignment already exists in the
external repo (with pre-sync enabled), we still cannot be sure that the
tag is present in the internal repository, since we only push the tag we
originally want to sync.

This commit makes sure that we also push into the internal repo the tag
which contains the alignment changes, just in case.

Thanks to @jochrist for reporting this bug!