### PR TITLE
[v1.3][NCL-3980] Sync target repo tags when running /adjust

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -107,6 +107,11 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
     ref = adjustspec["ref"]
     yield from clone.push_sync_changes(work_dir, ref, "origin")
 
+    # At this point the target repository might have the ref we want to sync, but the local repository might not have all the tags
+    # from the target repository. We need to sync tags because we use it to know if we have tags with existing changes or if we
+    # need to create tags of format <version>-<sha> if existing tag with name <version> exists after pme changes
+    yield from git["fetch_tags"](work_dir)
+
 @asyncio.coroutine
 def adjust(adjustspec, repo_provider):
     """

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -134,6 +134,7 @@ def git_provider():
                 cmd=["git", "show-ref", "--quiet", "--tags", ref, "--"],
                 cwd=dir,
                 desc="Ignore this.",
+                print_cmd=True
             )
             return True
         except Exception as e:
@@ -320,6 +321,15 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def fetch_tags(dir):
+        yield from expect_ok(
+            cmd=["git", "fetch", "--tags"],
+            desc="Could not fetch tags with git",
+            cwd=dir,
+            print_cmd=True
+        )
+
+    @asyncio.coroutine
     def delete_branch(dir, branch_name):
         yield from expect_ok(
             cmd=["git", "branch", "-d", branch_name],
@@ -489,6 +499,7 @@ def git_provider():
         "push": push,
         "push_all": push_all,
         "push_with_tags": push_with_tags,
+        "fetch_tags": fetch_tags,
         "is_branch": is_branch,
         "is_tag": is_tag,
         "clone": clone,


### PR DESCRIPTION
This is required to know if:
- existing tag with same contents already exists in target repository if
  repo sync is on

- if existing tag with name <version> exists, push new tag with name
  <version>-<sha>