### PR TITLE
[NCL-3984] Use checkout -f when changing branch

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -100,7 +100,7 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
     git_user = configuration.get("git_username")
 
     yield from git["clone"](work_dir, adjustspec["originRepoUrl"])  # Clone origin
-    yield from git["checkout"](work_dir, adjustspec["ref"])  # Checkout ref
+    yield from git["checkout"](work_dir, adjustspec["ref"], force=True)  # Checkout ref
     yield from git["remove_remote"](work_dir, "origin")  # Remove origin remote
     yield from git["add_remote"](work_dir, "origin", asutil.add_username_url(internal_repo_url.readwrite, git_user))  # Add target remote
 
@@ -145,7 +145,7 @@ def adjust(adjustspec, repo_provider):
             git_user = c.get("git_username")
 
             yield from git["clone"](work_dir, asutil.add_username_url(repo_url.readwrite, git_user))  # Clone origin
-            yield from git["checkout"](work_dir, adjustspec["ref"])  # Checkout ref
+            yield from git["checkout"](work_dir, adjustspec["ref"], force=True)  # Checkout ref
 
         ### Adjust Phase ###
         yield from asgit.setup_commiter(expect_ok, work_dir)

--- a/repour/clone.py
+++ b/repour/clone.py
@@ -69,7 +69,7 @@ def clone_git(clonespec):
 
         if "ref" in clonespec and clonespec["ref"]:
             yield from git["clone"](clone_dir, clonespec["originRepoUrl"])  # Clone origin
-            yield from git["checkout"](clone_dir, clonespec["ref"])  # Checkout ref
+            yield from git["checkout"](clone_dir, clonespec["ref"], force=True)  # Checkout ref
             yield from git["add_remote"](clone_dir, "target", asutil.add_username_url(clonespec["targetRepoUrl"], git_user))  # Add target remote
 
             ref = clonespec["ref"]

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -45,10 +45,16 @@ def git_provider():
         )
 
     @asyncio.coroutine
-    def checkout(dir, ref):
+    def checkout(dir, ref, force=False):
+
         # Checkout tag or branch or commit-id
+        cmd=["git", "checkout", ref]
+
+        if force:
+            cmd.append("-f")
+
         yield from expect_ok(
-            cmd=["git", "checkout", ref],
+            cmd=cmd,
             cwd=dir,
             desc="Could not checkout ref {ref} with git".format(**locals()),
             print_cmd=True


### PR DESCRIPTION
On a fresh clone, sometimes we still get 'diffs' in the working tree
because of weird behavious between CRLF and LF file ending conversion
between windows and linux, and the .gitattributes file.

This prevents us from checking out the branch/tag we want. So by using
the '-f' option in checkout, this allows us change branch/tag and
discard the local changes.

See: https://help.github.com/articles/dealing-with-line-endings/