### PR TITLE
[NCL-4069] Handle case with adjust and pre-sync on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [NCL-4047] Print useful error message when user is trying to sync with a private Github repository without the required permissions
+
 ### Fixed
 - [NCL-4039] Repour does not require a value for `originRepoUrl` on the `/adjust` endpoint if sync is false
+
+### Changed
+- [NCL-4069] Handle case with adjust with pre-build-sync on, when ref is present in downstream repository only. In that case, no sync is required
 
 
 # Template

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -153,6 +153,18 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def does_sha_exist(dir, ref):
+        try:  # TODO improve, its ugly
+            yield from expect_ok(
+                cmd=["git", "cat-file", "-e", ref + "^{commit}"],
+                cwd=dir,
+                desc="Ignore this.",
+            )
+            return True
+        except Exception as e:
+            return False
+
+    @asyncio.coroutine
     def is_branch(dir, ref):
         try:  # TODO improve, its ugly
             yield from expect_ok(
@@ -576,5 +588,6 @@ def git_provider():
         "write_tree": write_tree,
         "get_tag_from_tree_sha": get_tag_from_tree_sha,
         "disable_bare_repository": disable_bare_repository,
-        "reset_hard": reset_hard
+        "reset_hard": reset_hard,
+        "does_sha_exist": does_sha_exist
     }


### PR DESCRIPTION
The case is when the sync is on, and the downstream repository has the
ref but not the upstream repository. In that case we shouldn't fail and
go as before.

Before it was failing because it was trying to checkout the ref from the
upstream repository.