### PR TITLE
 [NCL-4082] Endpoint to translate external scm to internal 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [NCL-4047] Print useful error message when user is trying to sync with a private Github repository without the required permissions
 
+- [NCL-4082] Add endpoint `/git-external-to-internal` to translate external Git repository links into internal Git repository links
+
 ### Fixed
 - [NCL-4039] Repour does not require a value for `originRepoUrl` on the `/adjust` endpoint if sync is false
 

--- a/repour/auth/auth.py
+++ b/repour/auth/auth.py
@@ -35,7 +35,7 @@ def get_oauth2_jwt_handler(app, next_handler):
             response = yield from next_handler(request)
             return response
 
-        if request.path == "/":
+        if request.path == "/" or request.path == "/git-external-to-internal":
             # we don't authenticate for request to '/'. We'll show relevant repour information there
             response = yield from next_handler(request)
             return response

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -30,5 +30,6 @@
     }
   },
   "git_username": "",
+  "git_url_internal_template": "",
   "temp_build_indy_group": ""
 }

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -20,7 +20,8 @@
       "cliJarPathAbsolute": "/home/repour/pom-manipulation-cli.jar",
       "defaultParameters": [
         "..."
-      ]
+      ],
+      "temp_build_indy_group": ""
     }
   },
   "scm": {
@@ -30,6 +31,5 @@
     }
   },
   "git_username": "",
-  "git_url_internal_template": "",
-  "temp_build_indy_group": ""
+  "git_url_internal_template": ""
 }

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -543,7 +543,12 @@ def git_provider():
 
         returns: string with proper message to tell the user what to do
         """
-        github_user = os.environ['PRIVATE_GITHUB_USER']
+        try:
+            github_user = os.environ['PRIVATE_GITHUB_USER']
+        except keyError:
+            # if environment variable not specified
+            logger.warn("PRIVATE_GITHUB_USER environment variable not specified!")
+            github_user = None
 
         if github_user:
             further_desc = "If the Github repository is a private repository, you need to add the Github user " + \

--- a/repour/server/endpoint/external_to_internal.py
+++ b/repour/server/endpoint/external_to_internal.py
@@ -1,0 +1,67 @@
+import asyncio
+import re
+
+from urllib.parse import urlparse
+
+from ...config import config
+
+@asyncio.coroutine
+def translate(external_to_internal_spec, repo_provider):
+
+    external_url = external_to_internal_spec["external_url"]
+
+    internal_url = yield from translate_external_to_internal(external_url)
+
+    result = {
+        "external_url": external_url,
+        "internal_url": internal_url
+    }
+
+    return result
+
+@asyncio.coroutine
+def translate_external_to_internal(external_git_url):
+    """ Logic from original maitai code to do this: found in GitUrlParser.java#generateInternalGitRepoName """
+
+    c = yield from config.get_configuration()
+    gerrit_server = c.get("git_url_internal_template", None)
+
+    if gerrit_server is None:
+        raise Exception("git_url_internal_template not specified in the Repour config!")
+    elif not gerrit_server.endswith("/"):
+        gerrit_server = gerrit_server + "/"
+
+    result = urlparse(external_git_url)
+
+    scheme = result.scheme
+    path = result.path
+
+    acceptable_schemes = ['https', 'git', 'git+ssh', 'ssh']
+
+    if scheme == '':
+        raise Exception("Scheme in url is empty! Error!")
+
+    if scheme not in acceptable_schemes:
+        raise Exception("Scheme '{0}' not accepted!'".format(scheme))
+
+    path_parts = path.split('/')
+
+    repository = None
+
+    if path_parts[-1]:
+        repository = re.sub(r'\.git$', '', path_parts[-1])
+
+    organization = None
+
+    # if organization name is 'gerrit', don't use it then
+    if len(path_parts) > 1 and path_parts[-2] != "gerrit" and path_parts[-2]:
+        organization = path_parts[-2]
+
+    if organization and repository:
+        repo_name = organization + "/" + repository
+    elif repository:
+        repo_name = repository
+    else:
+        raise Exception("Could not translate the URL: No repository specified!")
+
+    return gerrit_server + repo_name + ".git"

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -70,6 +70,12 @@ adjust_modeb = Schema(
     extra=False,
 )
 
+external_to_internal = Schema(
+    {"external_url": nonempty_str},
+    required=True,
+    extra=False,
+)
+
 #
 # Pull
 #

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from .endpoint import cancel
 from .endpoint import endpoint
 from .endpoint import info
+from .endpoint import external_to_internal
 from .endpoint import ws
 from ..adjust import adjust
 from .. import clone
@@ -38,6 +39,8 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
     logger.debug("Adding application resources")
     app["repo_provider"] = repo.provider_types[repo_provider["type"]](**repo_provider["params"])
 
+    external_to_internal_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.external_to_internal, external_to_internal.translate, repour_url)
+
     if repo_provider["type"] == "modeb":
         logger.warn("Mode B selected, guarantees rescinded")
         pull_source = endpoint.validated_json_endpoint(shutdown_callbacks, validation.pull_modeb, pull.pull, repour_url)
@@ -48,6 +51,7 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
 
     logger.debug("Setting up handlers")
     app.router.add_route("GET", "/", info.handle_request)
+    app.router.add_route("POST", "/git-external-to-internal", external_to_internal_source)
     app.router.add_route("POST", "/pull", pull_source)
     app.router.add_route("POST", "/adjust", adjust_source)
     app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))


### PR DESCRIPTION
Description of endpoint
=======================

Endpoint is: /git-external-to-internal
The endpoint is not authenticated. Therefore any user can access it.

Request
--------

POST /git-external-to-internal
```

{"external_url": "<url>"}
```

Responses
--------
- Success!

HTTP status: 200
```
{
    "external_url": "<url>",
    "internal_url": "<internal-url>",
    "log": "<logs>"
}
```
- Failure

HTTP status: 500
```
{
    "error_traceback": "<error-traceback>",
    "error_type": "<error-type>",
    "log": "<logs>"
}
```

Configuration Changes
=====================
We need to add key 'git_url_internal_template' to the configuration.
This is used as the first part of the internal url.

e.g 'git_url_internal_template': 'git+ssh://<private-git-server>/gerrit/'