### PR TITLE
Fix multidict to 4.4.0

### DIFF
--- a/venv/container.txt
+++ b/venv/container.txt
@@ -1,4 +1,7 @@
 chardet==3.0.4
+
+# 4.4.1 multidict requires Python >= 3.5
+multidict==4.4.0
 aiohttp==2.2.0
 # 2.0.1 is the last version that supports Python 3.4
 async-timeout==2.0.1


### PR DESCRIPTION
Multidict 4.4.1 requires Python >= 3.5, and right now we only use Python
3.4.

Fix multidict version to 4.4.0 to make it work on Python 3.4