### PR TITLE
Bugfix: check correct variable that contains tag information

### DIFF
--- a/repour/clone.py
+++ b/repour/clone.py
@@ -49,7 +49,7 @@ def push_sync_changes(work_dir, ref, remote="origin"):
         # to push the SHA
         tag_name = "repour-sync-" + ref
 
-        tag_already_exists = yield from git["is_tag"](work_dir, ref)
+        tag_already_exists = yield from git["is_tag"](work_dir, tag_name)
 
         if not tag_already_exists:
             yield from git["add_tag"](work_dir, tag_name)


### PR DESCRIPTION
In a previous commit, we were checking if a tag already exists.
Unfortunately we were using the wrong variable (ref) to compare the tag.
We should use the variable 'tag_name' instead