### PR TITLE
[NCL-4120] Repour append commit id to tag on devel mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - <yyyy>-<mm>-<dd>
 ### Added
-- Section
+- [NCL-4120] Repour dev mode is added! It'll help with preventing tag collision
+             when syncing between internal repositories during testing
 
 ### Removed
 - [NCL-3872] `/pull` endpoint and tests

--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -156,9 +156,15 @@ def commit_push_tag(expect_ok, repo_dir,
     # Check if tag name already exists, if so, modify tag name to <tag>-{commitid}
     does_tag_exist = yield from git["is_tag"](repo_dir, tag_name)
 
+    shorthand_commit_id = commit_id[:8] # only show first 8 chars of commit id
+
     if does_tag_exist:
-        shorthand_commit_id = commit_id[:8] # only show first 8 chars of commit id
         logger.info("Tag {0} already exists! Changing it to {0}-{1}".format(tag_name, shorthand_commit_id))
+        tag_name = "{0}-{1}".format(tag_name, shorthand_commit_id)
+    elif c.get("mode", "prod") == "devel":
+        # NCL-4120: if devel mode activated create tag with format: <tag>-<commitid> all the time
+        # reason is to avoid conflict between official internal git repository and test git repository when we try to sync from official internal to test git
+        logger.info("Repour Devel mode activated! Changing tag to {0}-{1} to avoid conflict between internal git repositories".format(tag_name, shorthand_commit_id))
         tag_name = "{0}-{1}".format(tag_name, shorthand_commit_id)
 
     try:

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -31,5 +31,6 @@
     }
   },
   "git_username": "",
-  "git_url_internal_template": ""
+  "git_url_internal_template": "",
+  "mode": "devel"
 }


### PR DESCRIPTION
During testing of repour, we use the `/adjust` endpoint with sync on between the
official internal git repository (which we consider as the external
repo) and a test internal git repository. There is a particular case
when the syncing is problematic:

- test internal git repository is aligned from upstream tag 1.0.0 and repour
  creates tag 1.0.0-company-1

- some time later the official git repository is aligned from upstream
  tag 1.0.0 in official repour instance and creates tag 1.0.0-company-1

Then the next time we sync the official internal git repo to the test
internal git repository, it fails because we have the same tag
(1.0.0-company-1) pointing to different commitids! (alignment will be
done slightly differently between the test repour and production repour
instance)

So instead this commit adds the 'devel' mode to repour that we'll
activate in test repour instances. It is activated by adding to the
repour top-level JSON config:

```
{
    ...
    "mode": "devel"
}
```

By default the mode is assumed to be 'prod'. What this does is that on
using `/adjust` in the test repour instances, instead of creating a tag
with format '<version>', it'll create a tag for format
'<version>-<commit id>'. This will help prevent tag commitid collisions
the next time we try to sync repositories.

### All Submissions:

* [x] Have you added a note in the CHANGELOG.md for your change?
* [x] Have you added unit tests for your change?
