### PR TITLE
[NC-4231] Fix bug in repour syncing of branches

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -128,12 +128,12 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
     if ref_exists:
         yield from git["checkout"](work_dir, adjustspec["ref"], force=True)  # Checkout ref
 
-        yield from git["remove_remote"](work_dir, "origin")  # Remove origin remote
+        yield from git["rename_remote"](work_dir, "origin", "origin_remote")  # Rename origin remote
         yield from git["add_remote"](work_dir, "origin", asutil.add_username_url(internal_repo_url.readwrite, git_user))  # Add target remote
 
         ref = adjustspec["ref"]
         # Sync
-        yield from clone.push_sync_changes(work_dir, ref, "origin")
+        yield from clone.push_sync_changes(work_dir, ref, "origin", origin_remote="origin_remote")
 
     else:
         logger.warn("Upstream repository does not have the 'ref'. Trying to see if 'ref' present in downstream repository")

--- a/repour/clone.py
+++ b/repour/clone.py
@@ -18,7 +18,7 @@ expect_ok = asutil.expect_ok_closure(exception.CommandError)
 git = git_provider.git_provider()
 
 @asyncio.coroutine
-def push_sync_changes(work_dir, ref, remote="origin"):
+def push_sync_changes(work_dir, ref, remote="origin", origin_remote="origin"):
     """ This function is used when we want to sync a repository with another one
         It assumes that you have already set the remote to be the 'other' repository
 
@@ -30,9 +30,10 @@ def push_sync_changes(work_dir, ref, remote="origin"):
         - work_dir: :str: location of git repository
         - ref: Git ref to sync
         - remote: remote to push the ref to
+        - origin_remote: remote that was cloned from
     """
 
-    isRefBranch = yield from git["is_branch"](work_dir, ref)  # if ref is a branch, we don't have to create one
+    isRefBranch = yield from git["is_branch"](work_dir, ref, origin=origin_remote)  # if ref is a branch, we don't have to create one
     isRefTag = yield from git["is_tag"](work_dir, ref)
 
     if isRefBranch:

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -144,6 +144,15 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def rename_remote(dir, old_name, new_name):
+        yield from expect_ok(
+            cmd=["git", "remote", "rename", old_name, new_name],
+            cwd=dir,
+            desc="Could not remove rename remote '{}' to '{}'".format(old_name, new_name),
+            print_cmd=True
+        )
+
+    @asyncio.coroutine
     def add_remote(dir, name, url):
         yield from expect_ok(
             cmd=["git", "remote", "add", name, url, "--"],
@@ -608,6 +617,7 @@ def git_provider():
         "init": init,
         "add_tag": add_tag,
         "remove_remote": remove_remote,
+        "rename_remote": rename_remote,
         "add_remote": add_remote,
         "add_branch": add_branch,
         "delete_branch": delete_branch,


### PR DESCRIPTION
When syncing branches on the `/adjust` endpoint, we:

1. git clone the upstream repository and checkout the ref
2. remove the remote 'origin' and set remote 'origin' to the internal repository
3. push and sync the 'ref' to sync to internal repository
4. Run PME
5. Create a commit, tag and push to internal repository

The issue is that on step 2, removing the remote 'origin' affects step 3.

Step 3 tries to identify if the ref to sync is a branch or a tag or a
sha. The reasoning is that if it's a branch or a tag, we push them as-is
to the internal repository. If it's a sha, we need to push it as a tag
to the internal repository.

On Step 3, we assume by default that the branch to check is
'remotes/origin/<ref>'. Unfortunately since we removed the remote
'origin' on Step 2, step 3 thinks the ref is not a branch
(remotes/origin/<ref> does not exist anymore when the remote is
removed). It instead incorrectly considers the ref as a sha.

The fix for this is that on Step 2, instead of removing the remote
'origin', we rename it to 'origin_remote'. Then on Step 3, we check if
the branch exists from 'remotes/origin_remote/<ref>' instead.

Another question that might be asked is why don't we just set the remote
of the internal repository to another name, instead of using 'origin'.
The reason is because this will affect other parts of the 'adjust' code
in subtle ways if different conditions are hit (like if the ref does not
exist at all)

### All Submissions:

* [ ] Have you added a note in the CHANGELOG.md for your change?
* [ ] Have you added unit tests for your change?
