### PR TITLE
[NCL-4285] If ref not found, it should be a user error

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -150,7 +150,8 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
             yield from git["checkout"](work_dir, adjustspec["ref"], force=True)  # Checkout ref
         else:
             logger.error("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed")
-            raise exception.AdjustError("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed")
+            raise exception.AdjustCommandError("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed",
+                                         [], exit_code=10)
 
 
 


### PR DESCRIPTION
user error is defined as an exit code less than 100

### All Submissions:

* [ ] Have you added a note in the CHANGELOG.md for your change?
* [ ] Have you added unit tests for your change?
