### PR TITLE
[v1.4][NCL-4285] If ref not found, it should be a user error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - <yyyy>-<mm>-<dd>
+### Changed
+- [NCL-4285] Syncs where the ref does not exist are now considered User error instead of system error
+
 ### Fixed
 - [NCL-4231] Fix bug in repour syncing of branches for `/adjust` endpoint
+
 
 ## [1.4.1] - 2018-11-13
 ### Changed

--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -149,7 +149,8 @@ def sync_external_repo(adjustspec, repo_provider, work_dir, configuration):
             yield from git["checkout"](work_dir, adjustspec["ref"], force=True)  # Checkout ref
         else:
             logger.error("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed")
-            raise exception.AdjustError("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed")
+            raise exception.AdjustCommandError("Both upstream and downstream repository do not have the 'ref' present. Cannot proceed",
+                                         [], exit_code=10)
 
 
 


### PR DESCRIPTION
user error is defined as an exit code less than 100

### All Submissions:

* [ ] Have you added a note in the CHANGELOG.md for your change?
* [ ] Have you added unit tests for your change?
