### PR TITLE
[NCL-4650] Provide commit id on /adjust

### DIFF
--- a/repour/asgit.py
+++ b/repour/asgit.py
@@ -79,6 +79,7 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
     # The following scheme does not include the origin_ref, although it is good
     # information, because it comprimises length and parsability too much.
     tag_name = None
+    commit = None
 
     # As many things as possible are controlled for the commit, so the commitid
     # can be used for deduplication.
@@ -92,6 +93,9 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
 
         # Find if there's already a tag for the tree sha above
         tag_name = yield from git["get_tag_from_tree_sha"](repo_dir, tree_sha)
+
+        if tag_name:
+            commit = yield from git["get_commit_from_tag_name"](repo_dir, tag_name)
 
         # Find if tree sha already exists in a tag
         # - yes -> return existing tag, if no_change_ok = true
@@ -108,6 +112,8 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
                                               operation_name, operation_description,
                                               no_change_ok, force_continue_on_no_changes,
                                               real_commit_time, specific_tag_name)
+
+        commit = yield from git["get_commit_from_tag_name"](repo_dir, tag_name)
     else:
         logger.info("Existing tag containing changes to commit is present. Using it")
         logger.info("Tag name is: {0}".format(tag_name))
@@ -121,6 +127,7 @@ def push_new_dedup_branch(expect_ok, repo_dir, repo_url, operation_name, operati
     else:
         return {
             "tag": tag_name,
+            "commit": commit,
             "url": {
                 "readwrite": repo_url.readwrite,
                 "readonly": repo_url.readonly,

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -516,6 +516,19 @@ def git_provider():
             if "does not have any commits yet" in e.stderr:
                 return None
 
+    @asyncio.coroutine
+    def get_commit_from_tag_name(repo_dir, tag_name):
+
+        commit = yield from expect_ok(
+                cmd=["git", "rev-list", "-n", "1", tag_name],
+                desc="Couldn't get the commit from tag with git",
+                stdout="text",
+                cwd=repo_dir,
+                print_cmd=True
+        )
+
+        return commit.strip()
+
 
     @asyncio.coroutine
     def clone_checkout_ref_auto(dir, url, ref):
@@ -639,6 +652,7 @@ def git_provider():
         "tag_annotated": tag_annotated,
         "write_tree": write_tree,
         "get_tag_from_tree_sha": get_tag_from_tree_sha,
+        "get_commit_from_tag_name": get_commit_from_tag_name,
         "disable_bare_repository": disable_bare_repository,
         "reset_hard": reset_hard,
         "does_sha_exist": does_sha_exist


### PR DESCRIPTION
We do provide the tag name as a result for the `/adjust` endpoint. But
we should also provide the commit id

### All Submissions:

* [ ] Have you added a note in the CHANGELOG.md for your change?
* [ ] Have you added unit tests for your change?
