### PR TITLE
[NCL-4768] Adjustments in Repour after Gradle analyzer plugin release

### DIFF
--- a/ADJUST_PROVIDERS.rst
+++ b/ADJUST_PROVIDERS.rst
@@ -18,8 +18,7 @@ Configuration
     {
         "adjust": {
             "GRADLE": {
-                "gradleAnalyzerPluginVersion": "1.0.0",
-                "gradleAnalyzerPluginLibDir": "/home/goldmann/git/redhat/repour/libs",
+                "gradleAnalyzerPluginInitFilePath": "/opt/repour/analyzer-init.gradle",
                 "defaultParameters": [
                     "-DrestURL=http://da.custom.com/da/rest/v-1"
                 ]
@@ -30,19 +29,10 @@ Configuration
 .. note::
     The ``GRADLE`` key is required to be upper case.
 
-The ``gradleAnalyzerPluginVersion`` specifies the plugin version that is required to run the analyze phase.
-
-There are multiple ways how the plugin can be provided. Following options are available:
-
-1. It can be fetched from a custom directory specified as ``gradleAnalyzerPluginLibDir``,
-2. It can be fetched from local Maven repository,
-3. It can be fetched from Maven Central.
-
-.. warning::
-    Currently specifying ``gradleAnalyzerPluginLibDir`` is required. This should be an absolute path
-    to a directory where the analyze jar can be found.
-
-    This will be changed in the future versions after the plugin will be published to https://plugins.gradle.org/.
+The ``gradleAnalyzerPluginInitFilePath`` specifies the path on local disk to the Gradle init file responsible
+for triggering the analyzer plugin. This file should define the Gradle plugin version and location from
+where it should be fetched. Examples of working init files can be found on Maven Central for particular plugin versions:
+http://central.maven.org/maven2/org/jboss/gm/analyzer/analyzer/
 
 The ``defaultParameters`` key should specify at least ``restURL`` which is a URL to Dependency
 Analyzer (DA) REST interface.

--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -226,14 +226,14 @@ async def adjust_gradle(work_dir, c, adjustspec, adjust_result):
     if adjust_provider_config is None:
         raise Exception("Adjust execution '{0}' configuration not available. Please add the '{0}' section to your configuration file".format(gradle_provider.EXECUTION_NAME))
 
-    for parameter in ["gradleAnalyzerPluginVersion", "gradleAnalyzerPluginLibDir"]:
+    for parameter in ["gradleAnalyzerPluginInitFilePath"]:
         if parameter not in adjust_provider_config:
             raise Exception("Required {} configuration parameters: '{}' is missing in configuration file".format(gradle_provider.EXECUTION_NAME, parameter))
 
     default_parameters = adjust_provider_config.get("defaultParameters", [])
     extra_adjust_parameters = adjustspec.get("adjustParameters", {})
 
-    result = await gradle_provider.get_gradle_provider(adjust_provider_config["gradleAnalyzerPluginVersion"], adjust_provider_config["gradleAnalyzerPluginLibDir"], default_parameters) \
+    result = await gradle_provider.get_gradle_provider(adjust_provider_config["gradleAnalyzerPluginInitFilePath"], default_parameters) \
         (work_dir, extra_adjust_parameters, adjust_result)
 
     if "version" not in result['resultData']:


### PR DESCRIPTION
This makes use of the init file provided by the plugin.
It is expected that this file is provided and a path to it
is specified as `gradleAnalyzerPluginInitFilePath`.
