### PR TITLE
[NCL-4810] Add support for custom parameters for Gradle builds

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -37,6 +37,11 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
             temp_build_parameters.append(
                 "-DrestRepositoryGroup=" + specific_indy_group)
 
+        extra_parameters, subfolder = util.get_extra_parameters(
+            extra_adjust_parameters)
+
+        work_dir = os.path.join(work_dir, subfolder)
+
         logger.info("Adjusting in {}".format(work_dir))
         logger.info("Copying Gradle init file from '{}'".format(init_file_path))
         shutil.copy2(init_file_path, os.path.join(
@@ -54,7 +59,7 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
         )
 
         cmd = ["./gradlew", "--info", "--console", "plain", "--no-daemon", "--stacktrace",
-               "--init-script", INIT_SCRIPT_FILE_NAME, "generateAlignmentMetadata"] + default_parameters + temp_build_parameters
+               "--init-script", INIT_SCRIPT_FILE_NAME, "generateAlignmentMetadata"] + default_parameters + temp_build_parameters + extra_parameters
 
         result = await process_provider.get_process_provider(EXECUTION_NAME,
                                                              cmd,

--- a/repour/adjust/util.py
+++ b/repour/adjust/util.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import re
+import shlex
 
 from xml.dom import minidom
+
+from .. import exception
 
 logger = logging.getLogger(__name__)
 
@@ -91,3 +94,35 @@ def get_temp_build_timestamp(adjustspec):
         return temp_build_timestamp
     else:
         return None
+
+
+def get_extra_parameters(extra_adjust_parameters):
+    """
+    Get the extra PME parameters from PNC
+    If the PME parameters contain '--file=<folder>/pom.xml', then extract that folder
+    and remove that --file option from the list of extra params.
+    In PME 2.11 and PME 2.12, there is a bug where that option causes the file target/pom-manip-ext-result.json
+    to be badly generated. Fixed in PME 2.13+
+    See: PRODTASKS-361
+    Returns: tuple<list<string>, string>: list of params(minus the --file option), and folder where to run PME
+    If '--file' option not used, the folder will be an empty string
+    """
+    subfolder = ''
+
+    paramsString = extra_adjust_parameters.get("CUSTOM_PME_PARAMETERS", None)
+    if paramsString is None:
+        return [], subfolder
+    else:
+        params = shlex.split(paramsString)
+        for p in params:
+            if p[0] != "-":
+                desc = ('Parameters that do not start with dash "-" are not allowed. '
+                        + 'Found "{p}" in "{params}".'.format(**locals()))
+                raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
+            if p.startswith("--file"):
+                subfolder = p.replace("--file=", "").replace("pom.xml", "")
+
+        params_without_file_option = [
+            p for p in params if not p.startswith("--file=")]
+
+        return params_without_file_option, subfolder


### PR DESCRIPTION
This reuses the `CUSTOM_PME_PARAMETERS` variable and is subject
for refactoring after 1.7 release.

