### PR TITLE
[NCL-4810] Add support for custom parameters for Gradle builds - 1.7

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -39,6 +39,10 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
             temp_build_parameters.append(
                 "-DrestRepositoryGroup=" + specific_indy_group)
 
+        extra_parameters, subfolder = yield from util.get_extra_parameters(extra_adjust_parameters)
+
+        work_dir = os.path.join(work_dir, subfolder)
+
         logger.info("Adjusting in {}".format(work_dir))
         logger.info("Copying Gradle init file from '{}'".format(init_file_path))
         shutil.copy2(init_file_path, os.path.join(
@@ -56,7 +60,7 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
         )
 
         cmd = ["./gradlew", "--info", "--console", "plain", "--no-daemon", "--stacktrace",
-               "--init-script", INIT_SCRIPT_FILE_NAME, "generateAlignmentMetadata"] + default_parameters + temp_build_parameters
+               "--init-script", INIT_SCRIPT_FILE_NAME, "generateAlignmentMetadata"] + default_parameters + temp_build_parameters + extra_parameters
 
         result = yield from process_provider.get_process_provider(EXECUTION_NAME,
                                                                   cmd,

--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -92,37 +92,6 @@ def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_log
                 return None, None
 
     @asyncio.coroutine
-    def get_extra_parameters(extra_adjust_parameters):
-        """
-        Get the extra PME parameters from PNC
-        If the PME parameters contain '--file=<folder>/pom.xml', then extract that folder
-        and remove that --file option from the list of extra params.
-        In PME 2.11 and PME 2.12, there is a bug where that option causes the file target/pom-manip-ext-result.json
-        to be badly generated. Fixed in PME 2.13+
-        See: PRODTASKS-361
-        Returns: tuple<list<string>, string>: list of params(minus the --file option), and folder where to run PME
-        If '--file' option not used, the folder will be an empty string
-        """
-        subfolder = ''
-
-        paramsString = extra_adjust_parameters.get("CUSTOM_PME_PARAMETERS", None)
-        if paramsString is None:
-            return [], subfolder
-        else:
-            params = shlex.split(paramsString)
-            for p in params:
-                if p[0] != "-":
-                    desc = ('Parameters that do not start with dash "-" are not allowed. '
-                            + 'Found "{p}" in "{params}".'.format(**locals()))
-                    raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
-                if p.startswith("--file"):
-                    subfolder = p.replace("--file=", "").replace("pom.xml", "")
-
-            params_without_file_option = [p for p in params if not p.startswith("--file=")]
-
-            return params_without_file_option, subfolder
-
-    @asyncio.coroutine
     def adjust(repo_dir, extra_adjust_parameters, adjust_result):
         nonlocal execution_name
 
@@ -134,7 +103,7 @@ def get_pme_provider(execution_name, pme_jar_path, pme_parameters, output_to_log
         if specific_indy_group:
             temp_build_parameters.append("-DrestRepositoryGroup=" + specific_indy_group)
 
-        extra_parameters, subfolder = yield from get_extra_parameters(extra_adjust_parameters)
+        extra_parameters, subfolder = yield from util.get_extra_parameters(extra_adjust_parameters)
 
         # readjust the repo_dir to run PME from the folder where the root pom.xml is located
         # See: PRODTASKS-361


### PR DESCRIPTION
This reuses the `CUSTOM_PME_PARAMETERS` variable and is subject
for refactoring after 1.7 release.
