### PR TITLE
[v1.7][NCL-5064] Handle more cases to parse params from PME

### DIFF
--- a/repour/adjust/util.py
+++ b/repour/adjust/util.py
@@ -1,8 +1,8 @@
+import argparse
 import asyncio
 import logging
 import os
 import re
-import shlex
 
 from xml.dom import minidom
 
@@ -118,16 +118,12 @@ def get_extra_parameters(extra_adjust_parameters):
     if paramsString is None:
         return [], subfolder
     else:
-        params = shlex.split(paramsString)
-        for p in params:
-            if p[0] != "-":
-                desc = ('Parameters that do not start with dash "-" are not allowed. '
-                        + 'Found "{p}" in "{params}".'.format(**locals()))
-                raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
-            if p.startswith("--file"):
-                subfolder = p.replace("--file=", "").replace("pom.xml", "")
 
-        params_without_file_option = [
-            p for p in params if not p.startswith("--file=")]
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-f", "--file")
+        (options, remaining_args) = parser.parse_known_args(paramsString.split())
 
-        return params_without_file_option, subfolder
+        if options.file is not None:
+            subfolder = options.file.replace("pom.xml", "")
+
+        return remaining_args, subfolder

--- a/test/test_adjust_utils.py
+++ b/test/test_adjust_utils.py
@@ -1,0 +1,28 @@
+import asyncio
+import unittest
+import repour.adjust.util as util
+
+loop = asyncio.get_event_loop()
+
+class TestAdjustUtil(unittest.TestCase):
+
+    def test_util_file_option(self):
+
+        param = {"CUSTOM_PME_PARAMETERS": "-Dtest=test -f haha/pom.xml"}
+
+        remaining_args, filepath = loop.run_until_complete(util.get_extra_parameters(param))
+
+        self.assertEqual(remaining_args, ['-Dtest=test'])
+        self.assertEqual(filepath, "haha/")
+
+        param_file = {"CUSTOM_PME_PARAMETERS": "--file hoho/pom.xml -Dtest=test"}
+
+        remaining_args, filepath = loop.run_until_complete(util.get_extra_parameters(param_file))
+        self.assertEqual(remaining_args, ['-Dtest=test'])
+        self.assertEqual(filepath, "hoho/")
+
+        param_file_equal = {"CUSTOM_PME_PARAMETERS": "-Dtest2=test2 --file=hihi -Dtest=test"}
+
+        remaining_args, filepath = loop.run_until_complete(util.get_extra_parameters(param_file_equal))
+        self.assertEqual(remaining_args, ['-Dtest2=test2', '-Dtest=test'])
+        self.assertEqual(filepath, "hihi")


### PR DESCRIPTION
This is done by using argparse to parse the versions.

Cases tested:
```
-f <file>
--file=<file>
--file <file>
```
### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [x] Have you added unit tests for your change?
