### PR TITLE
[v1.7][NCL-4974] Add monitoring to Repour

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -715,6 +715,25 @@ GitLab integration tests will be executed using the local Docker server. To run 
 1. ensure your vex environment includes `venv/integration-test.txt`
 2. prefix `REPOUR_RUN_IT=1` before the `unittest` command, to set the triggering environment variable. For example: `REPOUR_RUN_IT=1 vex rpo python -m unittest`
 
+== Monitoring
+We currently monitor endpoints requests and error by using the Prometheus client, exposing the metrics in the `/metrics` endpoint. We can optionally export the data to Graphite if environment variable `GRAPHITE_SERVER` and `GRAPHITE_KEY`` are defined. `GRAPHITE_KEY` is the prefix for the data, and is usually set to the url of the server.
+
+You can also override the default port for the Graphite server with `GRAPHITE_PORT`
+
+The metrics monitored are:
+
+- time request of `/adjust`, `/clone`, `/cancel`, `/external-to-internal`, `/`, and sending result to callback urls
+  * This covers latency and traffic
+
+- errors:
+  * validation json error
+  * 400 response
+  * 500 response
+  * can't send response to callback
+
+- CPU, memory, GC
+  * Covers saturation
+
 == License
 
 The content of this repository is released under the ASL 2.0, as provided in the LICENSE file. See the NOTICE file for the copyright statement and a list of contributors. By submitting a "pull request" or otherwise contributing to this repository, you agree to license your contribution under the license identified above.

--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -15,6 +15,13 @@ from .. import clone
 from .. import exception
 from ..config import config
 from ..scm import git_provider
+from prometheus_client import Summary
+from prometheus_client import Histogram
+from prometheus_async.aio import time
+
+REQ_TIME = Summary("adjust_req_time", "time spent with adjust endpoint")
+REQ_HISTOGRAM_TIME = Histogram("adjust_req_histogram", "Histogram for adjust endpoint",
+                               buckets=[1, 10, 60, 120, 300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000, 3300, 3600, 4500, 5400, 6300, 7200])
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +137,9 @@ def handle_temp_build(adjustspec, adjust_provider_config):
 
     return temp_build_enabled, timestamp, specific_indy_group
 
+
+@time(REQ_TIME)
+@time(REQ_HISTOGRAM_TIME)
 @asyncio.coroutine
 def adjust(adjustspec, repo_provider):
     """

--- a/repour/clone.py
+++ b/repour/clone.py
@@ -7,8 +7,15 @@ from . import exception
 from .config import config
 from .scm import git_provider
 
+from prometheus_client import Summary
+from prometheus_client import Histogram
+from prometheus_async.aio import time
+
 logger = logging.getLogger(__name__)
 
+
+REQ_TIME = Summary("clone_req_time", "time spent with clone endpoint")
+REQ_HISTOGRAM_TIME = Histogram("clone_req_histogram", "Histogram for clone endpoint", buckets=[1, 10, 60, 120, 300, 600, 900, 1200, 1500, 1800, 3600])
 #
 # Utility
 #
@@ -58,6 +65,9 @@ def push_sync_changes(work_dir, ref, remote="origin", origin_remote="origin"):
         else:
             logger.info("Tag already exists in internal repository. Not pushing anything")
 
+
+@time(REQ_TIME)
+@time(REQ_HISTOGRAM_TIME)
 @asyncio.coroutine
 def clone(clonespec, repo_provider):
     if clonespec["type"] in scm_types:

--- a/repour/server/endpoint/cancel.py
+++ b/repour/server/endpoint/cancel.py
@@ -4,8 +4,17 @@ import logging
 
 from aiohttp import web
 
+from prometheus_client import Summary
+from prometheus_client import Histogram
+from prometheus_async.aio import time
+
 logger = logging.getLogger(__name__)
 
+REQ_TIME = Summary("cancel_req_time", "time spent with cancel endpoint")
+REQ_HISTOGRAM_TIME = Histogram("cancel_req_histogram", "Histogram for cancel endpoint")
+
+@time(REQ_TIME)
+@time(REQ_HISTOGRAM_TIME)
 @asyncio.coroutine
 def handle_cancel(request):
 

--- a/repour/server/endpoint/external_to_internal.py
+++ b/repour/server/endpoint/external_to_internal.py
@@ -5,6 +5,15 @@ from urllib.parse import urlparse
 
 from ...config import config
 
+from prometheus_client import Summary
+from prometheus_client import Histogram
+from prometheus_async.aio import time
+
+REQ_TIME = Summary("external_to_internal_req_time", "time spent with external_to_internal endpoint")
+REQ_HISTOGRAM_TIME = Histogram("external_to_internal_req_histogram", "Histogram for external_to_internal endpoint")
+
+@time(REQ_TIME)
+@time(REQ_HISTOGRAM_TIME)
 @asyncio.coroutine
 def translate(external_to_internal_spec, repo_provider):
 

--- a/repour/server/endpoint/info.py
+++ b/repour/server/endpoint/info.py
@@ -7,6 +7,16 @@ from ...scm import git_provider
 from ... import exception
 
 
+from prometheus_client import Summary
+from prometheus_client import Histogram
+from prometheus_async.aio import time
+
+
+REQ_TIME = Summary("info_req_time", "time spent with info endpoint")
+REQ_HISTOGRAM_TIME = Histogram("info_req_histogram", "Histogram for info endpoint")
+
+@time(REQ_TIME)
+@time(REQ_HISTOGRAM_TIME)
 @asyncio.coroutine
 def handle_request(request):
     version = repour.__version__

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+import prometheus_async.aio as aio
 
 from aiohttp import web
 
@@ -16,6 +18,7 @@ from .. import websockets
 from .endpoint import validation
 from ..auth import auth
 from ..config import config
+from prometheus_client.bridge.graphite import GraphiteBridge
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +60,9 @@ def init(loop, bind, repo_provider, repour_url, adjust_provider):
     app.router.add_route("POST", "/clone", endpoint.validated_json_endpoint(shutdown_callbacks, validation.clone, clone.clone, repour_url))
     app.router.add_route("POST", "/cancel/{task_id}", cancel.handle_cancel)
     app.router.add_route("GET", "/callback/{callback_id}", ws.handle_socket)
+    app.router.add_route("GET", "/metrics", aio.web.server_stats)
+
+    yield from setup_graphite_exporter()
 
     logger.debug("Creating asyncio server")
     srv = yield from loop.create_server(app.make_handler(), bind["address"], bind["port"])
@@ -102,3 +108,24 @@ def start_server(bind, repo_provider, repour_url, adjust_provider):
         elif len(exception_results) == 1:
             raise exception_results[0]
         loop.close()
+
+
+@asyncio.coroutine
+def setup_graphite_exporter():
+
+    graphite_server = os.environ.get("GRAPHITE_SERVER", None)
+    graphite_key = os.environ.get("GRAPHITE_KEY", None)
+    graphite_port = os.environ.get("GRAPHITE_PORT", 2003)
+
+    if graphite_server is None or graphite_key is None:
+        logger.warn(
+            "Graphite server (" + str(graphite_server) + ") or Graphite key (" + str(graphite_key) + ") is not defined. Not setting up Monitoring graphite server!")
+        return
+
+    logger.info("Monitoring graphite server setup! Reporting to server: " + graphite_server + ":" + str(graphite_port) + " with prefix: " + str(graphite_key))
+
+
+    gb = GraphiteBridge((graphite_server, graphite_port))
+    gb.start(60.0, prefix=graphite_key)
+
+

--- a/venv/container.txt
+++ b/venv/container.txt
@@ -7,3 +7,9 @@ aiohttp==2.2.0
 async-timeout==2.0.1
 voluptuous==0.10.5
 python-jose==1.3.2
+
+# Need to use that version to work with prometheus_async
+prometheus_client==0.4.1
+
+# 17.5.0 should be compatible with aiohttp 2.2.0
+prometheus_async==17.5.0

--- a/venv/runtime.txt
+++ b/venv/runtime.txt
@@ -5,3 +5,9 @@ async-timeout==2.0.1
 pyyaml==3.12
 voluptuous==0.10.5
 python-jose==1.3.2
+
+# Need to use that version to work with prometheus_async
+prometheus_client==0.4.1
+
+# 17.5.0 should be compatible with aiohttp 2.2.0
+prometheus_async==17.5.0


### PR DESCRIPTION
We currently monitor endpoints requests and error by using the
Prometheus client, exposing the metrics in the `/metrics` endpoint. We
can optionally export the data to Graphite if environment variable
`GRAPHITE_SERVER` and `GRAPHITE_KEY`` are defined. `GRAPHITE_KEY` is the
prefix for the data, and is usually set to the url of the server.

You can also override the default port for the Graphite server with
`GRAPHITE_PORT`

The metrics monitored are:

- time request of `/adjust`, `/clone`, `/cancel`,
  `/external-to-internal`, `/`, and sending result to callback urls

  * This covers latency and traffic

- errors:
  * validation json error
  * 400 response
  * 500 response
  * can't send response to callback

- CPU, memory, GC
  * Covers saturation

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
