### PR TITLE
[v1.7][NCL-5158] Add support for user to specify JVM for gradle

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -18,6 +18,8 @@ EXECUTION_NAME = "GRADLE"
 INIT_SCRIPT_FILE_NAME = "analyzer-init.gradle"
 MANIPULATION_FILE_NAME = "manipulation.json"
 
+REPOUR_JAVA_KEY = "-DRepour_Java="
+
 
 def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=None, timestamp=None):
 
@@ -61,7 +63,15 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
             live_log=True
         )
 
-        cmd = [command_gradle, "--info", "--console", "plain", "--no-daemon", "--stacktrace",
+        jvm_version = get_jvm_from_extra_parameters(extra_parameters)
+
+        if jvm_version:
+            JAVA_HOME = 'JAVA_HOME=/usr/lib/jvm/java-' + jvm_version + '-openjdk'
+            cmd = [JAVA_HOME]
+        else:
+            cmd = []
+
+        cmd = cmd + [command_gradle, "--info", "--console", "plain", "--no-daemon", "--stacktrace",
                "--init-script", INIT_SCRIPT_FILE_NAME, "generateAlignmentMetadata"] + default_parameters + temp_build_parameters + extra_parameters
 
         result = yield from process_provider.get_process_provider(EXECUTION_NAME,
@@ -137,3 +147,16 @@ def get_command_gradle(work_dir):
         command_gradle = './gradlew'
 
     return command_gradle
+
+
+def get_jvm_from_extra_parameters(extra_parameters):
+    """
+    If repour JVM option specified, return the option value. Otherwise return None
+    """
+
+    for parameter in extra_parameters:
+
+        if REPOUR_JAVA_KEY in parameter:
+            return parameter.replace(REPOUR_JAVA_KEY, '')
+    else:
+        return None

--- a/test/test_gradle_provider.py
+++ b/test/test_gradle_provider.py
@@ -22,3 +22,15 @@ class TestGradleProvider(unittest.TestCase):
         self.assertEqual("gradle", gradle_provider.get_command_gradle(no_gradlew_folder.name))
 
         no_gradlew_folder.cleanup()
+
+    def test_get_jvm_from_extra_parameters(self):
+
+        extra_params = ['-DRepour_Java=1.8.0', 'not appropriate']
+        jvm = gradle_provider.get_jvm_from_extra_parameters(extra_params)
+
+        self.assertEqual('1.8.0', jvm)
+
+        extra_params = ['not really', 'not appropriate']
+
+        jvm_not_specified = gradle_provider.get_jvm_from_extra_parameters(extra_params)
+        self.assertEqual(None, jvm_not_specified)


### PR DESCRIPTION
In some cases, the user would like to specify which JVM to use for
Gradle manipulation.

This can be done by passing:

```
-DRepour_Java=<JVM version>
```
in the extra parameters.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
