### PR TITLE
[v1.7][NCL-5173] Use -- on checkout to disambiguate

### DIFF
--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -54,10 +54,14 @@ def git_provider():
     def checkout(dir, ref, force=False):
 
         # Checkout tag or branch or commit-id
-        cmd=["git", "checkout", ref]
+        cmd=["git", "checkout"]
 
         if force:
             cmd.append("-f")
+
+        cmd.append(ref)
+        # See NCL-5173 why we need to add '--' at the end
+        cmd.append('--')
 
         try:
             yield from expect_ok(


### PR DESCRIPTION
This arises when a file in the tree has the same name as a branch. This
causes git to be confused and fails. So we pass '--' to tell git to
trust itself and that we want to checkout the branch.

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
