### PR TITLE
[NCL-5173] Use -- on checkout to disambiguate

### DIFF
--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -50,10 +50,14 @@ def git_provider():
     async def checkout(dir, ref, force=False):
 
         # Checkout tag or branch or commit-id
-        cmd=["git", "checkout", ref]
+        cmd=["git", "checkout"]
 
         if force:
             cmd.append("-f")
+
+        cmd.append(ref)
+        # See NCL-5173 why we need to add '--' at the end
+        cmd.append('--')
 
         try:
             await expect_ok(


### PR DESCRIPTION
This arises when a file in the tree has the same name as a branch. This
causes git to be confused and fails. So we pass '--' to tell git to
trust itself and that we want to checkout the branch.

Must be used with a recent version of Git (2.18.1)

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
