### PR TITLE
[NCL-5225] Print the cmd to run for adjust

### DIFF
--- a/repour/adjust/process_provider.py
+++ b/repour/adjust/process_provider.py
@@ -24,7 +24,7 @@ def get_process_provider(execution_name, cmd, get_result_data=None, log_context_
     async def adjust(repo_dir, extra_adjust_parameters, adjust_result, env=None):
         # TODO: Why 'adjust_result' is ignored?
         nonlocal execution_name
-        logger.info('Executing "{execution_name}" using (sub)process adjust provider as "{cmd}".'.format(**locals()))
+        logger.info('Executing "{execution_name}" using (sub)process adjust provider as: '.format(**locals()) + ' '.join(cmd))
         log_executable_info(cmd)
         filled_cmd = [p.format(repo_dir=repo_dir) if p.startswith("{repo_dir}") else p for p in cmd]
 


### PR DESCRIPTION
This helps with debugging in the future since we can just copy pasta the
command logged into our machine.

Thanks to @rnc for the suggestion!

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
