### PR TITLE
[NCL-3579] Add kafka logging

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -772,6 +772,14 @@ The metrics monitored are:
 - CPU, memory, GC
   * Covers saturation
 
+== Kafka logging
+Repour can send logs to a Kafka server if and only if the appropriate settings
+are defined as env variables:
+
+- REPOUR_KAFKA_SERVER (format <host>:<port>)
+- REPOUR_KAFKA_TOPIC
+- REPOUR_KAFKA_CAFILE (location of the ca file to talk to kafka)
+
 == License
 
 The content of this repository is released under the ASL 2.0, as provided in the LICENSE file. See the NOTICE file for the copyright statement and a list of contributors. By submitting a "pull request" or otherwise contributing to this repository, you agree to license your contribution under the license identified above.

--- a/repour/logs/file_callback_log.py
+++ b/repour/logs/file_callback_log.py
@@ -15,6 +15,17 @@ def get_callback_log_path(callback_id):
     return os.path.join(CALLBACK_LOGS_PATH, callback_id + '.log')
 
 
+def has_event_loop():
+    """ If another thread (e.g kafka) is writing a log, the file_callback_log will be invoked inside that thread. In that case,
+    there is no event loop in that other thread and we need to know this
+    """
+    try:
+        asyncio.get_event_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
 class FileCallbackHandler(logging.StreamHandler):
     """
     Handler that logs into {directory}/{callback_id}.log
@@ -34,7 +45,11 @@ class FileCallbackHandler(logging.StreamHandler):
 
     def emit(self, record):
         try:
-            task = asyncio.Task.current_task()
+            if (has_event_loop()):
+                task = asyncio.Task.current_task()
+            else:
+                task = None
+
 
             if task is not None:
                 callback_id = getattr(task, "callback_id", None)

--- a/venv/container.txt
+++ b/venv/container.txt
@@ -5,3 +5,5 @@ pyyaml==5.1.2
 
 prometheus_client==0.7.1
 prometheus_async==19.2.0
+
+kafka-logging-handler==0.2.3


### PR DESCRIPTION
This commit adds support for sending logs to a Kafka instance. It relies
on the Red Hat's 'kafka-logging-handler' library for its task.

To activate the handler, 3 environment variables need to be defined:

- REPOUR_KAFKA_SERVER (format <host>:<port>)
- REPOUR_KAFKA_TOPIC
- REPOUR_KAFKA_CAFILE (location of the ca file to talk to kafka)

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
