### PR TITLE
[v1.8][NCL-3579] Add kafka logging

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -734,6 +734,14 @@ The metrics monitored are:
 - CPU, memory, GC
   * Covers saturation
 
+== Kafka logging
+Repour can send logs to a Kafka server if and only if the appropriate settings
+are defined as env variables:
+
+- REPOUR_KAFKA_SERVER (format <host>:<port>)
+- REPOUR_KAFKA_TOPIC
+- REPOUR_KAFKA_CAFILE (location of the ca file to talk to kafka)
+
 == License
 
 The content of this repository is released under the ASL 2.0, as provided in the LICENSE file. See the NOTICE file for the copyright statement and a list of contributors. By submitting a "pull request" or otherwise contributing to this repository, you agree to license your contribution under the license identified above.

--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -53,16 +53,6 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
 
         command_gradle = get_command_gradle(work_dir)
 
-        output = yield from expect_ok(
-            cmd=[command_gradle, "--version"],
-            desc="Failed getting Gradle version",
-            cwd=work_dir,
-            stdout=stdout_options["text"],
-            stderr=stderr_options["stdout"],
-            print_cmd=True
-        )
-        logger.info(output)
-
         jvm_version = util.get_jvm_from_extra_parameters(extra_parameters)
 
         if jvm_version:
@@ -70,6 +60,17 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
             logger.info("Specifying JAVA_HOME: " + env['JAVA_HOME'])
         else:
             env = None
+
+        output = yield from expect_ok(
+            cmd=[command_gradle, "--version"],
+            desc="Failed getting Gradle version",
+            cwd=work_dir,
+            stdout=stdout_options["text"],
+            stderr=stderr_options["stdout"],
+            print_cmd=True,
+            env=env
+        )
+        logger.info(output)
 
         if 'JAVA_HOME' in env:
             yield from util.print_java_version(java_bin_dir=env['JAVA_HOME'])

--- a/repour/main.py
+++ b/repour/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 
+from kafka_logger.handlers import KafkaLoggingHandler
 from .logs import file_callback_log
 from .logs import websocket_log
 
@@ -13,11 +14,22 @@ class ContextLogRecord(logging.LogRecord):
     no_context_found = "NoContext"
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        task = asyncio.Task.current_task()
+        if self.has_event_loop():
+            task = asyncio.Task.current_task()
+        else:
+            task = None
         if task is not None:
             self.log_context = getattr(task, "log_context", self.no_context_found)
         else:
             self.log_context = self.no_context_found
+
+    def has_event_loop(self):
+        try:
+            asyncio.get_event_loop()
+            return True
+        except RuntimeError:
+            return False
+
 
 def override(config, config_coords, args, arg_name):
     if getattr(args, arg_name, None) is not None:
@@ -66,6 +78,11 @@ def run_container_subcommand(args):
     from .server import server
 
     # Log to stdout/stderr only (no file)
+    kafka_server = os.environ.get("REPOUR_KAFKA_SERVER")
+    kafka_topic = os.environ.get("REPOUR_KAFKA_TOPIC")
+    kafka_cafile = os.environ.get("REPOUR_KAFKA_CAFILE")
+
+    configure_logging(logging.INFO, kafka_server=kafka_server, kafka_topic=kafka_topic, kafka_cafile=kafka_cafile)
     configure_logging(logging.INFO)
 
     # Read required config from env vars, most of it is hardcoded though
@@ -187,7 +204,7 @@ def create_argparser():
 
     return parser
 
-def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count=0, silent=False):
+def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count=0, silent=False, kafka_server=None, kafka_topic=None, kafka_cafile=None):
     logging.setLogRecordFactory(ContextLogRecord)
 
     formatter = logging.Formatter(
@@ -222,6 +239,17 @@ def configure_logging(default_level, log_path=None, verbose_count=0, quiet_count
 
     log_level = default_level + (10 * quiet_count) - (10 * verbose_count)
     root_logger.setLevel(log_level)
+
+    if kafka_server and kafka_topic and kafka_cafile:
+        logger.info("Setting up Kafka logging handler")
+        # we only care if you fail, kafka
+        logger_kafka = logging.getLogger("kafka")
+        logger_kafka.setLevel(logging.ERROR)
+
+        kafka_handler_obj = KafkaLoggingHandler(kafka_server,
+                                                kafka_topic,
+                                                ssl_cafile=kafka_cafile)
+        root_logger.addHandler(kafka_handler_obj)
 
 def load_config(config_path):
     import yaml

--- a/venv/container.txt
+++ b/venv/container.txt
@@ -13,3 +13,5 @@ prometheus_client==0.4.1
 
 # 17.5.0 should be compatible with aiohttp 2.2.0
 prometheus_async==17.5.0
+
+kafka-logging-handler==0.2.3

--- a/venv/integration-test.txt
+++ b/venv/integration-test.txt
@@ -1,2 +1,4 @@
 docker-py==1.5.0
 requests==2.8.1
+
+kafka-logging-handler==0.2.3

--- a/venv/runtime.txt
+++ b/venv/runtime.txt
@@ -11,3 +11,5 @@ prometheus_client==0.4.1
 
 # 17.5.0 should be compatible with aiohttp 2.2.0
 prometheus_async==17.5.0
+
+kafka-logging-handler==0.2.3


### PR DESCRIPTION
This commit adds support for sending logs to a Kafka instance. It relies
on the Red Hat's 'kafka-logging-handler' library for its task.

To activate the handler, 3 environment variables need to be defined:

- REPOUR_KAFKA_SERVER (format <host>:<port>)
- REPOUR_KAFKA_TOPIC
- REPOUR_KAFKA_CAFILE (location of the ca file to talk to kafka)

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
