### PR TITLE
Pass the env var when getting the gradle version

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -52,16 +52,6 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
 
         command_gradle = get_command_gradle(work_dir)
 
-        output = await expect_ok(
-            cmd=[command_gradle, "--version"],
-            desc="Failed getting Gradle version",
-            cwd=work_dir,
-            stdout=stdout_options["text"],
-            stderr=stderr_options["stdout"],
-            print_cmd=True
-        )
-        logger.info(output)
-
         jvm_version = util.get_jvm_from_extra_parameters(extra_parameters)
 
         if jvm_version:
@@ -69,6 +59,17 @@ def get_gradle_provider(init_file_path, default_parameters, specific_indy_group=
             logger.info("Specifying JAVA_HOME: " + env['JAVA_HOME'])
         else:
             env = None
+
+        output = await expect_ok(
+            cmd=[command_gradle, "--version"],
+            desc="Failed getting Gradle version",
+            cwd=work_dir,
+            stdout=stdout_options["text"],
+            stderr=stderr_options["stdout"],
+            print_cmd=True,
+            env=env
+        )
+        logger.info(output)
 
         if 'JAVA_HOME' in env:
             await util.print_java_version(java_bin_dir = env['JAVA_HOME'] + "/bin")


### PR DESCRIPTION
The env var contains the JDK specified by the user.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
