### PR TITLE
 [NCL-5067] Capture log-context headers, and pass along

### DIFF
--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -116,12 +116,15 @@ def get_pme_provider(
         # readjust the repo_dir to run PME from the folder where the root pom.xml is located
         # See: PRODTASKS-361
         repo_dir = os.path.join(repo_dir, subfolder)
+        log_context_value = await util.generate_user_context()
+        log_context_parameter = ["--log-context=" + log_context_value]
 
         cmd = (
             [location + "java", "-jar", pme_jar_path]
             + pme_parameters
             + temp_build_parameters
             + extra_parameters
+            + log_context_parameter
         )
 
         logger.info(

--- a/repour/adjust/util.py
+++ b/repour/adjust/util.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import os
 import re
@@ -171,3 +172,13 @@ async def print_java_version(java_bin_dir=""):
         print_cmd=True,
     )
     logger.info(output)
+
+
+async def generate_user_context():
+    """ For now, returns a string of key=value,key=value """
+    current_task = asyncio.Task.current_task()
+    return "log-user-id={},log-request-context={},log-process-context={}".format(
+        current_task.log_user_id,
+        current_task.log_request_context,
+        current_task.log_process_context,
+    )

--- a/repour/main.py
+++ b/repour/main.py
@@ -13,6 +13,9 @@ logger = logging.getLogger(__name__)
 
 class ContextLogRecord(logging.LogRecord):
     no_context_found = "NoContext"
+    no_userid_found = "NoUserIdContext"
+    no_request_context_found = "NoRequestContext"
+    no_process_context_found = "NoProcessContext"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -22,8 +25,18 @@ class ContextLogRecord(logging.LogRecord):
             task = None
         if task is not None:
             self.log_context = getattr(task, "log_context", self.no_context_found)
+            self.log_user_id = getattr(task, "log_user_id", self.no_userid_found)
+            self.log_request_context = getattr(
+                task, "log_request_context", self.no_request_context_found
+            )
+            self.log_process_context = getattr(
+                task, "log_process_context", self.no_process_context_found
+            )
         else:
             self.log_context = self.no_context_found
+            self.log_user_id = self.no_userid_found
+            self.log_request_context = self.no_request_context_found
+            self.log_process_context = self.no_process_context_found
 
     def has_event_loop(self):
         try:
@@ -222,7 +235,7 @@ def configure_logging(
     logging.setLogRecordFactory(ContextLogRecord)
 
     formatter = logging.Formatter(
-        fmt="{asctime} [{levelname}] [{log_context}] {name}:{lineno} {message}",
+        fmt="{asctime} [{levelname}] [{log_context}:{log_user_id}:{log_request_context}:{log_process_context}] {name}:{lineno} {message}",
         style="{",
     )
 


### PR DESCRIPTION
The headers are passed along to the callback server (Maitai), and to PME
for now.

GME and project-manipulator do not yet handle log contexts.

The format of the log-context passed to PME is currently:

```
--log-context=<key1>=<value1>,<key2>=<value2>
```
### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
