### PR TITLE
[NCL-5098] Use ':' instead of '=' as delimiter

### DIFF
--- a/repour/adjust/util.py
+++ b/repour/adjust/util.py
@@ -176,9 +176,9 @@ async def print_java_version(java_bin_dir=""):
 
 
 async def generate_user_context():
-    """ For now, returns a string of key=value,key=value """
+    """ For now, returns a string of key:value,key:value """
     current_task = asyncio.Task.current_task()
-    return "log-user-id={},log-request-context={},log-process-context={},log-expires={},log-tmp={}".format(
+    return "log-user-id:{},log-request-context:{},log-process-context:{},log-expires:{},log-tmp:{}".format(
         current_task.log_user_id,
         current_task.log_request_context,
         current_task.log_process_context,


### PR DESCRIPTION
The delimiter is used to separate the key and value for the HTTP headers

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
