### PR TITLE
set loggerName so that bifrost processes repour data

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -32,8 +32,12 @@ class ContextLogRecord(logging.LogRecord):
             # afterwards
             self.mdc = copy.copy(getattr(task, "mdc", {}))
             self.log_context = getattr(task, "log_context", self.no_context_found)
+
+            # required for bifrost for streaming logs
+            self.loggerName = getattr(task, "loggerName", self.no_context_found)
         else:
             self.log_context = self.no_context_found
+            self.loggerName = self.no_context_found
 
     def has_event_loop(self):
         try:

--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -101,11 +101,16 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):
         callback_id = create_callback_id()
 
         asyncio.Task.current_task().log_context = log_context
+
+        # required for bifrost for streaming logs
+        asyncio.Task.current_task().loggerName = "org.jboss.pnc._userlog_"
+
         log_util.add_update_mdc_key_value_in_task("userId", log_user_id)
         log_util.add_update_mdc_key_value_in_task("requestContext", log_request_context)
         log_util.add_update_mdc_key_value_in_task("processContext", log_process_context)
         log_util.add_update_mdc_key_value_in_task("expires", log_expires)
         log_util.add_update_mdc_key_value_in_task("tmp", log_tmp)
+
         asyncio.Task.current_task().callback_id = callback_id
 
         try:
@@ -316,6 +321,7 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):
             )
             callback_task = request.app.loop.create_task(do_callback(spec["callback"]))
             callback_task.log_context = log_context
+            callback_task.loggerName = asyncio.Task.current_task().loggerName
             callback_task.mdc = asyncio.Task.current_task().mdc
             callback_task.callback_id = callback_id
             # Set the task_id if provided in the request


### PR DESCRIPTION
The loggerName is set to 'org.jboss.pnc._userlog_'

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
