### PR TITLE
[NCL-5090] Verify if the adjust params use non-authorized urls

### DIFF
--- a/repour/asutil.py
+++ b/repour/asutil.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import os
+import re
 import shutil
 import tempfile
 import urllib.parse
@@ -232,3 +233,31 @@ def safe_remove_file(path):
         os.remove(path)
     except OSError:
         pass
+
+
+def list_urls_from_string(text):
+    """
+    From: https://stackoverflow.com/a/48769624/2907906
+    Modified to require the protocol (http:// or https://) to be present
+
+    It'll return a list of urls present in the string
+    """
+    return re.findall("(?:(?:https?):\/\/)[\w/\-?=%.]+\.[\w/\-?=%.]+", text)
+
+
+def list_non_origin_urls_from_string(origin_url, text):
+    """
+    Given a string, list all the urls that do not end with 'origin_url'.
+    """
+
+    result = []
+    urls = list_urls_from_string(text)
+
+    for url in urls:
+
+        url_parsed = urllib.parse.urlparse(url)
+
+        if not url_parsed.netloc.endswith(origin_url):
+            result.append(url)
+
+    return result

--- a/test/test_asutil.py
+++ b/test/test_asutil.py
@@ -131,3 +131,17 @@ class TestExpectOk(unittest.TestCase):
             loop.run_until_complete(expect_ok(["printf", self.t], stdout="single")),
             self.l[0],
         )
+
+    def test_list_non_origin_urls_from_string(self):
+
+        origin_url = "testme.com"
+        text = "-Pgmail -DgroovyScripts=http://hola.testme.com/test?bee=boo&jee=text"
+
+        self.assertEqual(
+            [], repour.asutil.list_non_origin_urls_from_string(origin_url, text)
+        )
+
+        text2 = "-Pgmail -DgroovyScripts=http://testme.booya.com?bee=boo -Dheeha=http://todo.testme.com"
+        self.assertEqual(
+            1, len(repour.asutil.list_non_origin_urls_from_string(origin_url, text2))
+        )


### PR DESCRIPTION
A new configuration has to be added:
- adjust_authorized_url

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
