### PR TITLE
[v1.8][NCLSUP-62] Explicitly add file 'gradle/gme-repos.gradle'

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -10,6 +10,9 @@ from string import Template
 from . import process_provider
 from . import util
 from .. import asutil
+from ..scm import git_provider
+
+git = git_provider.git_provider()
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +72,10 @@ def get_gradle_provider(init_file_path, gme_jar_path, default_parameters, defaul
                                                                   cmd,
                                                                   get_result_data=get_result_data,
                                                                   send_log=True)(work_dir, extra_adjust_parameters, adjust_result)
+
+        if gme_repos_dot_gradle_present(work_dir):
+            logger.info("Explicitly adding file {}".format(os.path.join(work_dir, 'gradle', 'gme-repos.gradle')))
+            yield from git["add_file"](work_dir, os.path.join('gradle', 'gme-repos.gradle'), force=True)
 
         return result
 
@@ -130,3 +137,7 @@ def get_gradle_provider(init_file_path, gme_jar_path, default_parameters, defaul
 
 def gradlew_path_present(work_dir):
     return os.path.exists(os.path.join(work_dir, 'gradlew'))
+
+
+def gme_repos_dot_gradle_present(work_dir):
+    return os.path.exists(os.path.join(work_dir, 'gradle', 'gme-repos.gradle'))

--- a/repour/scm/git_provider.py
+++ b/repour/scm/git_provider.py
@@ -418,6 +418,26 @@ def git_provider():
         )
 
     @asyncio.coroutine
+    def add_file(dir, file_path, force=False):
+        """
+        file_path  is relative to the dir
+
+        Add individual file to Git. force option provided to ignore .gitignore if needed
+        """
+        command = ["git", "add"]
+        if force:
+            command.append("-f")
+        command.append(file_path)
+
+        yield from expect_ok(
+            cmd=command,
+            desc="Could not add file with git",
+            cwd=dir,
+            print_cmd=True
+        )
+
+
+    @asyncio.coroutine
     def fetch_tags(dir, remote="origin"):
         try:
             yield from expect_ok(
@@ -667,6 +687,7 @@ def git_provider():
         "current_branch": current_branch,
         "create_branch_checkout": create_branch_checkout,
         "add_all": add_all,
+        "add_file": add_file,
         "tag_annotated": tag_annotated,
         "write_tree": write_tree,
         "get_tag_from_tree_sha": get_tag_from_tree_sha,


### PR DESCRIPTION
This avoid cases where the 'gradle' folder is added in the .gitignore,
and therefore the result of the alignment gets lost.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
