### PR TITLE
[NCLSUP-62] Explicitly add file 'gradle/gme-repos.gradle'

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -8,6 +8,7 @@ from string import Template
 
 from .. import asutil
 from . import process_provider, util
+from repour.lib.scm import git
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,16 @@ def get_gradle_provider(
             results_file=MANIPULATION_FILE_NAME,
         )(work_dir, extra_adjust_parameters, adjust_result)
 
+        if gme_repos_dot_gradle_present(work_dir):
+            logger.info(
+                "Explicitly adding file {}".format(
+                    os.path.join(work_dir, "gradle", "gme-repos.gradle")
+                )
+            )
+            await git.add_file(
+                work_dir, os.path.join("gradle", "gme-repos.gradle"), force=True
+            )
+
         adjust_result["adjustType"] = result["adjustType"]
         adjust_result["resultData"] = result["resultData"]
 
@@ -159,3 +170,7 @@ def get_gradle_provider(
 
 def gradlew_path_present(work_dir):
     return os.path.exists(os.path.join(work_dir, "gradlew"))
+
+
+def gme_repos_dot_gradle_present(work_dir):
+    return os.path.exists(os.path.join(work_dir, "gradle", "gme-repos.gradle"))

--- a/repour/lib/scm/git.py
+++ b/repour/lib/scm/git.py
@@ -424,6 +424,21 @@ async def add_all(dir):
     )
 
 
+async def add_file(dir, file_path, force=False):
+    """
+    file_path  is relative to the dir
+    Add individual file to Git. force option provided to ignore .gitignore if needed
+    """
+    command = ["git", "add"]
+    if force:
+        command.append("-f")
+    command.append(file_path)
+
+    await expect_ok(
+        cmd=command, desc="Could not add file with git", cwd=dir, print_cmd=True
+    )
+
+
 async def fetch_tags(dir, remote="origin"):
     try:
         await expect_ok(


### PR DESCRIPTION
This avoid cases where the 'gradle' folder is added in the .gitignore,
and therefore the result of the alignment gets lost.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
