### PR TITLE
[NCL-6165] Add brewPullActive to `adjust` request

### DIFF
--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -67,6 +67,7 @@ adjust_raw = {
     Optional("taskId"): null_or_str,
     Optional("buildType"): nonempty_str,
     Optional("defaultAlignmentParams"): Any(None, str),
+    Optional("brewPullActive"): bool,
 }
 
 adjust = Schema(adjust_raw, required=True, extra=False)


### PR DESCRIPTION
The `brewPullActive`, and the `tempBuild` flags will now be passed to
the alignment tools to determine what Indy group to talk to. We already
have the 'tempBuild' flag, so I'm just adding the `brewPullActive` one
for now.

The new `brewPullActive` flag is used to limit the usage of brew pull
and only be used as required. This is done to speed up builds.

The logic on how to use it for alignment will be done on another commit.
This commit is necessary so that we can work on the other bits (Maitai,
new Maitai, PNC) request DTOs.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
