### PR TITLE
[NCLSUP-225] Just let kafka logging fail

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -186,13 +186,16 @@ def configure_logging(
         logger_kafka = logging.getLogger("kafka")
         logger_kafka.setLevel(logging.ERROR)
 
-        kafka_handler_obj = KafkaLoggingHandler(
-            kafka_server,
-            kafka_topic,
-            log_preprocess=[adjust_kafka_timestamp],
-            ssl_cafile=kafka_cafile,
-        )
-        root_logger.addHandler(kafka_handler_obj)
+        try:
+            kafka_handler_obj = KafkaLoggingHandler(
+                kafka_server,
+                kafka_topic,
+                log_preprocess=[adjust_kafka_timestamp],
+                ssl_cafile=kafka_cafile,
+            )
+            root_logger.addHandler(kafka_handler_obj)
+        except Exception:
+            logger.exception("Kafka logging could not be setup")
 
 
 def adjust_kafka_timestamp(data):


### PR DESCRIPTION
If the Kafka server is down, we don't really log and fail. This commit
just captures the failure and moves on to the next step

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
