### PR TITLE
[v2.0][NCLSUP-212] Improve logging of alignment

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -319,6 +319,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.2.0"
 
 [[package]]
+category = "main"
+description = "A least recently used (LRU) cache implementation"
+name = "pylru"
+optional = false
+python-versions = "*"
+version = "1.2.0"
+
+[[package]]
 category = "dev"
 description = "Python parsing module"
 name = "pyparsing"
@@ -483,7 +491,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "94ecd5a4eaf3eeb41f549b2db6b2c855f6244c0a34ec4f9aa6e00ae9bab6eeae"
+content-hash = "a44ff999763d6ea05388b60ddfbd20438d2927c7a55c41bf92b0fae7416e5513"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -636,6 +644,9 @@ pycodestyle = [
 pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
+]
+pylru = [
+    {file = "pylru-1.2.0.tar.gz", hash = "sha256:492f934bb98dc6c8b2370c02c95c65516ddc08c8f64d27f70087eb038621d297"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ kafka-logging-handler = "^0.2.3"
 flake8 = "^3.8"
 more-itertools = "^8.4.0"
 giturlparse = "^0.9.2"
+pylru = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.17"


### PR DESCRIPTION
Changes done
------------

The first big change I did was on the logging department. I noticed that
we were printing very slowly (1 log line per ms) and investigated the
reason. The root cause is the file_callback_log.py logging handler,
which is used for websocket live logs (kinda deprecated with live log
now handled by Kafka), and to send back the full logs to the caller.

It stores the logs of a particular request into a file. The embarassing
issue is that we were creating/closing a new file handler everytime a
new log is emitted, which I learned is very costly and slow!

Instead we cache the file handler in an LRU cache. On eviction, the file
handler is closed. This change alone got rid of the log slowness.

The second improvement is that instead of reading the alignment log line
by line, we now try to read up to 5000 bytes at a time (this is
approximately 50 lines). This is very useful in helping Repour catch up
with logs printed by the alignment tool.

Related to this, while reading logs from the alignment, Repour can
become unresponsive to other requests while it is busy in the log loop
(when reading huge amounts of logs). This is quite strange, and I can't
really explain why this happens since everything is async. Adding a
sleep in our log loop if we read exactly 5000 bytes of data vastly
improves the responsiveness of Repour. This in turns vastly improves the
readiness/liveness probes that Openshift runs on Repour to make sure if
it is available. Before, Openshift would kill Repour during huge
alignments because it would appear unresponsive.

Test used
---------
We used this script in PME to print a lot of logs:
```
import org.commonjava.maven.ext.core.groovy.PMEBaseScript
import org.commonjava.maven.ext.core.groovy.PMEInvocationPoint
import org.commonjava.maven.ext.core.groovy.InvocationStage
import org.commonjava.maven.ext.core.groovy.BaseScript
import org.commonjava.maven.ext.core.impl.Version
import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef

import java.lang.String
import groovy.util.logging.Slf4j

@PMEInvocationPoint(invocationPoint = InvocationStage.FIRST)
@PMEBaseScript BaseScript pme
for(i = 0; i < 50000; i++) {    println("Hello world") }
```

Test was performed in our stage environment.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
