### PR TITLE
[NCL-6553] Adapt to new file name for PME and GME

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ deps =
     pre-commit
     flake8
 commands =
-    poetry install -vvv
+    poetry install
     pre-commit run --all-files --show-diff-on-failure
     poetry run pytest test/
     flake8

--- a/repour/adjust/process_provider.py
+++ b/repour/adjust/process_provider.py
@@ -72,29 +72,9 @@ def get_process_provider(
         adjust_result_data = {}
 
         adjust_result_data["adjustType"] = execution_name
-        process_provider_result = await get_result_data(
+        adjust_result_data["resultData"] = await get_result_data(
             repo_dir, extra_adjust_parameters, results_file=results_file
         )
-
-        # RHPAM wants the data in that format to parse the execution root name and version
-        # We can set the groupId to null, and artifactId to the name of the build in those cases
-
-        # "VersioningState": {
-        #   "executionRootModified": {
-        #       "groupId": group_id,
-        #       "artifactId": artifact_id,
-        #       "version": version,
-        #   }
-        # }
-        process_provider_result["VersioningState"] = {
-            "executionRootModified": {
-                "groupId": None,
-                "artifactId": process_provider_result["name"],
-                "version": process_provider_result["version"],
-            }
-        }
-
-        adjust_result_data["resultData"] = process_provider_result
 
         return adjust_result_data
 

--- a/repour/adjust/project_manipulator_provider.py
+++ b/repour/adjust/project_manipulator_provider.py
@@ -42,6 +42,24 @@ def get_project_manipulator_provider(
 
         result_data = json.loads(raw_result_data)
 
+        # RHPAM wants the data in that format to parse the execution root name and version
+        # We can set the groupId to null, and artifactId to the name of the build in those cases
+
+        # "VersioningState": {
+        #   "executionRootModified": {
+        #       "groupId": group_id,
+        #       "artifactId": artifact_id,
+        #       "version": version,
+        #   }
+        # }
+        result_data["VersioningState"] = {
+            "executionRootModified": {
+                "groupId": None,
+                "artifactId": result_data["name"],
+                "version": result_data["version"],
+            }
+        }
+
         result_data["RemovedRepositories"] = []
 
         return result_data

--- a/test/test_pme_provider.py
+++ b/test/test_pme_provider.py
@@ -30,31 +30,6 @@ class TestPMEProvider(unittest.TestCase):
         )
         self.verify_result_format(result, "group", "artifact", None, [])
 
-    def test_parse_pme_result_pom_manip_ext_result_format(self):
-
-        group_id = "org.apache.activemq"
-        artifact_id = "artemis-pom"
-        version = "2.6.3.redhat-00021"
-
-        raw_result_data = {
-            "VersioningState": {
-                "executionRootModified": {
-                    "groupId": group_id,
-                    "artifactId": artifact_id,
-                    "version": version,
-                }
-            }
-        }
-        result = pme_provider.parse_pme_result_pom_manip_ext_result_format(
-            "/tmp", "", json.dumps(raw_result_data), None, None
-        )
-        self.verify_result_format(result, group_id, artifact_id, version, [])
-
-        result = pme_provider.parse_pme_result_pom_manip_ext_result_format(
-            "/tmp", "", json.dumps(raw_result_data), "group", "artifact"
-        )
-        self.verify_result_format(result, "group", "artifact", None, [])
-
     def verify_result_format(
         self, result, group_id, artifact_id, version, removed_repositories
     ):


### PR DESCRIPTION
PME 4.3 uses alignmentReport.json instead of manipulation.json
An upcoming version of GME (2.7?) will use alignmentReport.json instead
of manipulation.json also for reporting alignment results

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
