### PR TITLE
[v2.0][NCL-6553] Adapt to new file name for PME and GME

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ deps =
     pre-commit
     flake8
 commands =
-    poetry install -vvv
+    poetry install
     pre-commit run --all-files --show-diff-on-failure
     poetry run pytest test/
     flake8

--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 EXECUTION_NAME = "GRADLE"
 
 INIT_SCRIPT_FILE_NAME = "analyzer-init.gradle"
-ALIGNMENT_REPORT_FILE_NAME = "alignmentReport.json"
+ALIGNMENT_REPORT_FILE_NAME = "build/alignmentReport.json"
 GME_MANIPULATION_FILE_NAME = "manipulation.json"
 
 stdout_options = asutil.process_stdout_options

--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -8,6 +8,7 @@ from string import Template
 
 from .. import asutil
 from . import process_provider, util
+from . import pme_provider
 from repour.lib.scm import git
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,8 @@ logger = logging.getLogger(__name__)
 EXECUTION_NAME = "GRADLE"
 
 INIT_SCRIPT_FILE_NAME = "analyzer-init.gradle"
-MANIPULATION_FILE_NAME = "manipulation.json"
+ALIGNMENT_REPORT_FILE_NAME = "alignmentReport.json"
+GME_MANIPULATION_FILE_NAME = "manipulation.json"
 
 stdout_options = asutil.process_stdout_options
 stderr_options = asutil.process_stderr_options
@@ -89,11 +91,7 @@ def get_gradle_provider(
         )
 
         result = await process_provider.get_process_provider(
-            EXECUTION_NAME,
-            cmd,
-            get_result_data=get_result_data,
-            send_log=True,
-            results_file=MANIPULATION_FILE_NAME,
+            EXECUTION_NAME, cmd, get_result_data=get_result_data, send_log=True,
         )(work_dir, extra_adjust_parameters, adjust_result)
 
         if gme_repos_dot_gradle_present(work_dir):
@@ -105,13 +103,26 @@ def get_gradle_provider(
             await git.add_file(
                 work_dir, os.path.join("gradle", "gme-repos.gradle"), force=True
             )
+        (
+            override_group_id,
+            override_artifact_id,
+        ) = await pme_provider.get_extra_param_execution_root_name(
+            extra_adjust_parameters
+        )
 
         adjust_result["adjustType"] = result["adjustType"]
-        adjust_result["resultData"] = result["resultData"]
+        adjust_result["resultData"] = await get_result_data(
+            work_dir,
+            extra_parameters,
+            group_id=override_group_id,
+            artifact_id=override_artifact_id,
+        )
 
         return result
 
-    async def get_result_data(work_dir, extra_parameters, results_file=None):
+    async def get_result_data(
+        work_dir, extra_parameters, results_file=None, group_id=None, artifact_id=None
+    ):
         """ Read the manipulation.json file and return it as an object
 
         Format is:
@@ -128,52 +139,25 @@ def get_gradle_provider(
         }
 
         """
+        alignment_report_file_path = os.path.join(work_dir, ALIGNMENT_REPORT_FILE_NAME)
+        manipulation_file_path = os.path.join(work_dir, GME_MANIPULATION_FILE_NAME)
 
-        template = {
-            "VersioningState": {
-                "executionRootModified": {
-                    "groupId": None,
-                    "artifactId": None,
-                    "version": None,
-                }
-            },
-            "RemovedRepositories": [],
-        }
-
-        manipulation_file_path = os.path.join(work_dir, MANIPULATION_FILE_NAME)
-
-        logger.info(
-            "Reading '{}' file with alignment result".format(manipulation_file_path)
-        )
-
-        if not os.path.exists(manipulation_file_path):
-            raise Exception(
-                "Expected generated alignment file '{}' does not exist".format(
-                    manipulation_file_path
-                )
+        if os.path.isfile(alignment_report_file_path):
+            file_path = alignment_report_file_path
+            logger.info("Reading '{}' file with alignment result".format(file_path))
+            return pme_provider.parse_pme_result_manipulation_format(
+                work_dir,
+                default_parameters,
+                open(file_path).read(),
+                group_id,
+                artifact_id,
             )
-
-        with open(manipulation_file_path, "r") as f:
-            result = json.load(f)
-            template["VersioningState"]["executionRootModified"]["groupId"] = result[
-                "group"
-            ]
-            template["VersioningState"]["executionRootModified"]["artifactId"] = result[
-                "name"
-            ]
-            template["VersioningState"]["executionRootModified"]["version"] = result[
-                "version"
-            ]
-
-        try:
-            template["RemovedRepositories"] = util.get_removed_repos(
-                work_dir, default_parameters
+        else:
+            file_path = manipulation_file_path
+            logger.info("Reading '{}' file with alignment result".format(file_path))
+            return parse_gme_manipulation_json(
+                work_dir, file_path, default_parameters, group_id, artifact_id
             )
-        except FileNotFoundError as e:
-            logger.error("File for removed repositories could not be found")
-            logger.error(str(e))
-
-        return template
 
     return adjust
 
@@ -184,3 +168,48 @@ def gradlew_path_present(work_dir):
 
 def gme_repos_dot_gradle_present(work_dir):
     return os.path.exists(os.path.join(work_dir, "gradle", "gme-repos.gradle"))
+
+
+def parse_gme_manipulation_json(
+    work_dir, file_path, default_parameters, group_id=None, artifact_id=None
+):
+
+    template = {
+        "VersioningState": {
+            "executionRootModified": {
+                "groupId": None,
+                "artifactId": None,
+                "version": None,
+            }
+        },
+        "RemovedRepositories": [],
+    }
+
+    with open(file_path, "r") as f:
+        result = json.load(f)
+        template["VersioningState"]["executionRootModified"]["groupId"] = result[
+            "group"
+        ]
+        template["VersioningState"]["executionRootModified"]["artifactId"] = result[
+            "name"
+        ]
+        template["VersioningState"]["executionRootModified"]["version"] = result[
+            "version"
+        ]
+
+    if group_id is not None and artifact_id is not None:
+        logger.warning("Overriding the groupId of the result to: " + group_id)
+        template["VersioningState"]["executionRootModified"]["groupId"] = group_id
+
+        logger.warning("Overriding the artifactId of the result to: " + artifact_id)
+        template["VersioningState"]["executionRootModified"]["artifactId"] = artifact_id
+
+    try:
+        template["RemovedRepositories"] = util.get_removed_repos(
+            work_dir, default_parameters
+        )
+    except FileNotFoundError as e:
+        logger.error("File for removed repositories could not be found")
+        logger.error(str(e))
+
+    return template

--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -39,16 +39,21 @@ def get_pme_provider(
         pme_and_extra_params.extend(extra_parameters)
         pme_and_extra_params.extend(repour_parameters)
 
+        file_path = None
         if os.path.isfile(result_file_path_alignment_report):
             file_path = result_file_path_alignment_report
-        else:
+        elif os.path.isfile(result_file_path_manipulation):
             file_path = result_file_path_manipulation
 
-        with open(file_path, "r") as file:
-            logger.info("Getting results from file: " + file_path)
-            return parse_pme_result_manipulation_format(
-                work_dir, pme_and_extra_params, file.read(), group_id, artifact_id
-            )
+        if file_path is not None:
+            with open(file_path, "r") as file:
+                logger.info("Getting results from file: " + file_path)
+                return parse_pme_result_manipulation_format(
+                    work_dir, pme_and_extra_params, file.read(), group_id, artifact_id
+                )
+        else:
+            logger.warn("Couldn't capture any result file from PME")
+            return None
 
     def is_pme_disabled_via_extra_parameters(extra_adjust_parameters):
         """
@@ -268,7 +273,7 @@ async def get_gav_from_pom(pom_xml_file):
 async def create_pme_result_file(repo_dir):
 
     result_file_folder = repo_dir + "/target"
-    result_file_path = result_file_folder + "/pom-manip-ext-result.json"
+    result_file_path = result_file_folder + "/alignmentReport.json"
 
     # get data by reading the pom.xml directly
     pom_path = repo_dir + "/pom.xml"
@@ -280,12 +285,10 @@ async def create_pme_result_file(repo_dir):
         group_id, artifact_id, version = (None, None, None)
 
     pme_result = {
-        "VersioningState": {
-            "executionRootModified": {
-                "groupId": group_id,
-                "artifactId": artifact_id,
-                "version": version,
-            }
+        "executionRoot": {
+            "groupId": group_id,
+            "artifactId": artifact_id,
+            "version": version,
         }
     }
 

--- a/test/test_pme_provider.py
+++ b/test/test_pme_provider.py
@@ -30,31 +30,6 @@ class TestPMEProvider(unittest.TestCase):
         )
         self.verify_result_format(result, "group", "artifact", None, [])
 
-    def test_parse_pme_result_pom_manip_ext_result_format(self):
-
-        group_id = "org.apache.activemq"
-        artifact_id = "artemis-pom"
-        version = "2.6.3.redhat-00021"
-
-        raw_result_data = {
-            "VersioningState": {
-                "executionRootModified": {
-                    "groupId": group_id,
-                    "artifactId": artifact_id,
-                    "version": version,
-                }
-            }
-        }
-        result = pme_provider.parse_pme_result_pom_manip_ext_result_format(
-            "/tmp", "", json.dumps(raw_result_data), None, None
-        )
-        self.verify_result_format(result, group_id, artifact_id, version, [])
-
-        result = pme_provider.parse_pme_result_pom_manip_ext_result_format(
-            "/tmp", "", json.dumps(raw_result_data), "group", "artifact"
-        )
-        self.verify_result_format(result, "group", "artifact", None, [])
-
     def verify_result_format(
         self, result, group_id, artifact_id, version, removed_repositories
     ):


### PR DESCRIPTION
PME 4.3 uses alignmentReport.json instead of manipulation.json
An upcoming version of GME (2.7?) will use alignmentReport.json instead
of manipulation.json also for reporting alignment results

also:

No need for verbose poetry install

Also I think this will help jenkins from not crashing because it's
getting confused with the fancy poetry output

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
