### PR TITLE
[v2] Set aligned version if present

### DIFF
--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -324,6 +324,9 @@ def parse_pme_result_manipulation_format(
         pme_result["VersioningState"]["executionRootModified"]["artifactId"] = data[
             "executionRoot"
         ]["artifactId"]
+
+    # Set version if present in result file
+    if "executionRoot" in data and "version" in data["executionRoot"]:
         pme_result["VersioningState"]["executionRootModified"]["version"] = data[
             "executionRoot"
         ]["version"]

--- a/test/test_pme_provider.py
+++ b/test/test_pme_provider.py
@@ -28,7 +28,7 @@ class TestPMEProvider(unittest.TestCase):
         result = pme_provider.parse_pme_result_manipulation_format(
             "/tmp", "", json.dumps(raw_result_data), "group", "artifact"
         )
-        self.verify_result_format(result, "group", "artifact", None, [])
+        self.verify_result_format(result, "group", "artifact", version, [])
 
     def verify_result_format(
         self, result, group_id, artifact_id, version, removed_repositories


### PR DESCRIPTION
Before this commit, the aligned version would only be returned for PME
alignment if the artifactId / groupId were not overridden by the user.

This commit allows the aligned version to be set even when the
artifactId / groupId is overriden by the user

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
