### PR TITLE
[2.1][NCLSUP-435] Mark as user error when wrong input in alignment params

### DIFF
--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -56,28 +56,6 @@ def get_pme_provider(
             logger.warn("Couldn't capture any result file from PME")
             return None
 
-    def is_pme_disabled_via_extra_parameters(extra_adjust_parameters):
-        """
-        Check if PME is disabled via one of the parameters passed to PME by the user
-
-        return: :bool:
-        """
-        paramsString = extra_adjust_parameters.get("ALIGNMENT_PARAMETERS", None)
-
-        if paramsString is None:
-            return False
-
-        else:
-
-            params = shlex.split(paramsString)
-
-            for p in params:
-
-                if p.startswith("-Dmanipulation.disable=true"):
-                    return True
-            else:
-                return False
-
     async def adjust(repo_dir, extra_adjust_parameters, adjust_result):
         nonlocal execution_name
 
@@ -341,3 +319,30 @@ def parse_pme_result_manipulation_format(
         logger.error(str(e))
 
     return pme_result
+
+
+def is_pme_disabled_via_extra_parameters(extra_adjust_parameters):
+    """
+    Check if PME is disabled via one of the parameters passed to PME by the user
+
+    return: :bool:
+    """
+    paramsString = extra_adjust_parameters.get("ALIGNMENT_PARAMETERS", None)
+
+    if paramsString is None:
+        return False
+
+    else:
+
+        try:
+            params = shlex.split(paramsString)
+
+            for p in params:
+
+                if p.startswith("-Dmanipulation.disable=true"):
+                    return True
+            else:
+                return False
+        except Exception as e:
+            # it's a failed user error, not a system error
+            raise exception.AdjustCommandError(str(e), [], 10, stderr=str(e))

--- a/repour/adjust/scala_provider.py
+++ b/repour/adjust/scala_provider.py
@@ -27,27 +27,6 @@ def get_scala_provider(
         }
         return template
 
-    async def get_extra_parameters(extra_adjust_parameters):
-        """
-        Get the extra ALIGNMENT_PARAMETERS parameters from PNC
-        """
-        subfolder = ""
-
-        params_string = extra_adjust_parameters.get("ALIGNMENT_PARAMETERS", None)
-        if params_string is None:
-            return []
-        else:
-            params = shlex.split(params_string)
-            for p in params:
-                if p[0] != "-":
-                    desc = (
-                        'Parameters that do not start with dash "-" are not allowed. '
-                        + 'Found "{p}" in "{params}".'.format(**locals())
-                    )
-                    raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
-
-            return params
-
     async def adjust(work_dir, extra_adjust_parameters, adjust_result):
         alignment_parameters = ["-DrestMode=" + rest_mode]
 
@@ -95,3 +74,30 @@ def get_scala_provider(
         return result
 
     return adjust
+
+
+def get_extra_parameters(extra_adjust_parameters):
+    """
+    Get the extra ALIGNMENT_PARAMETERS parameters from PNC
+    """
+    subfolder = ""
+
+    params_string = extra_adjust_parameters.get("ALIGNMENT_PARAMETERS", None)
+    if params_string is None:
+        return []
+    else:
+        try:
+            params = shlex.split(params_string)
+        except Exception as e:
+            # it's a failed user error, not a system error
+            raise exception.AdjustCommandError(str(e), [], 10, stderr=str(e))
+
+        for p in params:
+            if p[0] != "-":
+                desc = (
+                    'Parameters that do not start with dash "-" are not allowed. '
+                    + 'Found "{p}" in "{params}".'.format(**locals())
+                )
+                raise exception.AdjustCommandError(desc, [], 10, stderr=desc)
+
+        return params

--- a/test/test_project_manipulator_provider.py
+++ b/test/test_project_manipulator_provider.py
@@ -1,0 +1,33 @@
+# flake8: noqa
+import json
+import unittest
+
+from repour import exception
+import repour.adjust.project_manipulator_provider as project_manipulator_provider
+
+
+class TestProjectManipulatorProvider(unittest.TestCase):
+    def test_get_extra_parameters(self):
+
+        param = {"ALIGNMENT_PARAMETERS": None}
+        self.assertEqual(project_manipulator_provider.get_extra_parameters(param), [])
+
+        param = {"ALIGNMENT_PARAMETERS": "-Dhello-world --letsgo"}
+        self.assertEqual(
+            project_manipulator_provider.get_extra_parameters(param),
+            ["-Dhello-world", "--letsgo"],
+        )
+
+        try:
+            param = {"ALIGNMENT_PARAMETERS": '-DdependencyOverride.*:*@*="'}
+            project_manipulator_provider.get_extra_parameters(param)
+            self.assertFalse(True, msg="An exception should be thrown here")
+        except exception.AdjustCommandError as e:
+            self.assertEqual(e.exit_code, 10)
+
+        try:
+            param = {"ALIGNMENT_PARAMETERS": "test 1234"}
+            project_manipulator_provider.get_extra_parameters(param)
+            self.assertFalse(True, msg="An exception should be thrown here")
+        except exception.AdjustCommandError as e:
+            self.assertEqual(e.exit_code, 10)

--- a/test/test_scala_manipulator.py
+++ b/test/test_scala_manipulator.py
@@ -1,0 +1,32 @@
+# flake8: noqa
+import json
+import unittest
+
+from repour import exception
+import repour.adjust.scala_provider as scala_provider
+
+
+class TestScalaProvider(unittest.TestCase):
+    def test_get_extra_parameters(self):
+
+        param = {"ALIGNMENT_PARAMETERS": None}
+        self.assertEqual(scala_provider.get_extra_parameters(param), [])
+
+        param = {"ALIGNMENT_PARAMETERS": "-Dhello-world --letsgo"}
+        self.assertEqual(
+            scala_provider.get_extra_parameters(param), ["-Dhello-world", "--letsgo"]
+        )
+
+        try:
+            param = {"ALIGNMENT_PARAMETERS": '-DdependencyOverride.*:*@*="'}
+            scala_provider.get_extra_parameters(param)
+            self.assertFalse(True, msg="An exception should be thrown here")
+        except exception.AdjustCommandError as e:
+            self.assertEqual(e.exit_code, 10)
+
+        try:
+            param = {"ALIGNMENT_PARAMETERS": "test 1234"}
+            scala_provider.get_extra_parameters(param)
+            self.assertFalse(True, msg="An exception should be thrown here")
+        except exception.AdjustCommandError as e:
+            self.assertEqual(e.exit_code, 10)


### PR DESCRIPTION
If a user enters a wrongly formatted alignment params (like unmatched
quotes), Repour fails to parse it and fails. That failure should be
marked as a User failed build rather than a system error.

### All Submissions:

* [x] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [x] Have you added unit tests for your change?
