### PR TITLE
[v2.1][NCLSUP-439] Support alignment from a merge-request

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -262,6 +262,12 @@ The response will contain the exact ref name as what was sent
 !===
 |===
 
+If the ref to align is a merge-request (Gitlab, with format '/merge-requests/<number>') or a pull-request (Github with format '/pull/<number>'),
+with sync switched on, the merge-request is checkout into a temporary branch, then the alignment tool is run, and the results are added in a commit
+and pushed in a tag that starts with 'Pull_Request-'. The latter is done to not create any confusing that the tag is from a merge-request.
+
+With sync on for a merge-request, the checkout is not pushed into the downstream repository in a branch, unlike for a regular ref. The commits in
+the checkout are indirectly present via the 'Pull_Request-<tag>' only.
 
 
 === Clone

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,0 +1,45 @@
+# flake8: noqa
+import asyncio
+import datetime
+import os
+import subprocess
+import time
+import unittest
+from test import util
+
+from repour.lib.scm import git
+import repour.asutil
+
+loop = asyncio.get_event_loop()
+expect_ok = repour.asutil.expect_ok_closure()
+
+
+class TestGit(unittest.TestCase):
+    def test_is_ref_a_pull_request(self):
+        self.assertTrue(git.is_ref_a_pull_request("merge-requests/1"))
+        self.assertTrue(git.is_ref_a_pull_request("merge-requests/45"))
+        self.assertTrue(git.is_ref_a_pull_request("merge-requests/80"))
+
+        self.assertTrue(git.is_ref_a_pull_request("pull/1"))
+        self.assertTrue(git.is_ref_a_pull_request("pull/45"))
+        self.assertTrue(git.is_ref_a_pull_request("pull/80"))
+
+        self.assertFalse(git.is_ref_a_pull_request("2.1.0.Final"))
+        self.assertFalse(git.is_ref_a_pull_request("temporary-myself"))
+
+    def test_modify_ref_to_be_fetchable(self):
+
+        modified, branch = git.modify_ref_to_be_fetchable("not-a-pr")
+
+        self.assertIsNone(modified)
+        self.assertIsNone(branch)
+
+        ref = "merge-requests/60"
+        modified, branch = git.modify_ref_to_be_fetchable(ref)
+
+        self.assertEqual(modified, ref + "/head:" + branch)
+
+        ref = "pull/3"
+        modified, branch = git.modify_ref_to_be_fetchable(ref)
+
+        self.assertEqual(modified, ref + "/head:" + branch)


### PR DESCRIPTION
If the ref to align is a merge-request (Gitlab, with format
'/merge-requests/<number>') or a pull-request (Github with format
'/pull/<number>'), with sync switched on, the merge-request is checkout
into a temporary branch, then the alignment tool is run, and the results
are added in a commit and pushed in a tag that starts with
'Pull_Request-'. The latter is done to not create any confusing that the
tag is from a merge-request.

With sync on for a merge-request, the checkout is not pushed into the
downstream repository in a branch, unlike for a regular ref. The commits
in the checkout are indirectly present via the 'Pull_Request-<tag>'
only.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
