### PR TITLE
[NCL-6882] Cut off logs after a certain size 

### DIFF
--- a/repour/lib/io/file_utils.py
+++ b/repour/lib/io/file_utils.py
@@ -1,0 +1,20 @@
+import os
+
+
+def read_last_bytes_of_file(file_path: str, size_in_bytes: int) -> str:
+    """
+    Return the last bytes of a file containing utf-8 formatted text rather than the whole contents. The last bytes is
+    determined by size_in_bytes
+
+    Parameters:
+    - file_path: file path to read
+    - size_in_bytes: amount of data to read in bytes
+
+    Returns:
+    - :str: of file content in utf-8 format
+    """
+    with open(file_path, "rb") as file:
+        # Note the minus sign
+        file.seek(-size_in_bytes, os.SEEK_END)
+        content = file.read().decode("utf-8")
+        return content

--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 import traceback
 
 import aiohttp
@@ -17,6 +18,7 @@ from prometheus_client import Counter, Histogram, Summary
 
 from repour import exception
 from repour.config import config
+from repour.lib.io import file_utils
 from repour.lib.logs import log_util
 from repour.lib.logs import file_callback_log
 from repour.server import validation
@@ -219,9 +221,23 @@ def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):
 
             log_file = file_callback_log.get_callback_log_path(callback_id)
             logs = ""
+
             if os.path.isfile(log_file):
-                with open(log_file, "r") as f:
-                    logs = f.read()
+
+                # if not defined in log, set it to max size of an int, aka no maximum log size
+                max_size_bytes = c.get("max_log_size_bytes", sys.maxsize)
+                size_log = os.path.getsize(log_file)
+
+                if size_log > max_size_bytes:
+                    # This log should be printed before we grab the final log file so that this error is included in the log file
+                    logger.error(
+                        "Log file is too big: {} > {}".format(size_log, max_size_bytes)
+                    )
+                    logs = file_utils.read_last_bytes_of_file(log_file, max_size_bytes)
+                    status = 400
+                else:
+                    with open(log_file, "r") as f:
+                        logs = f.read()
 
             obj["log"] = logs
             return status, obj

--- a/test/test_file_utils.py
+++ b/test/test_file_utils.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+
+from repour.lib.io import file_utils
+
+
+class TestFileUtils(unittest.TestCase):
+    def test_read_last_bytes_of_file(self):
+        fp = tempfile.NamedTemporaryFile()
+        fp.write(b"1234567890")
+        fp.flush()
+
+        data = file_utils.read_last_bytes_of_file(fp.name, 5)
+        self.assertEqual("67890", data)
+
+        fp.close()


### PR DESCRIPTION
Repour sends back the entire logs of an alignment in the callback.
However, we cannot send logs greater than a certain size because this
will cause OutOfMemory exceptions to the other services.

This commit:
- checks the size of the repour logs to send back no matter if the
  alignment succeeded or failed
- if the size is greater than the maximum allowed (say foo bytes), then
  we only return the last foo bytes of the repour logs since it's more
  likely it'll contain the most important information
- mark the alignment as failed

The max size log can be configured in the `repour_config.json` as:
```
{
    ...
    "max_log_size_bytes": 12345
}
```

If this setting is not specified, then we don't activate this feature**

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
