### PR TITLE
[NCL-7083] Only add versionSuffixAlternatives on some conditions

### DIFF
--- a/repour/adjust/gradle_provider.py
+++ b/repour/adjust/gradle_provider.py
@@ -53,10 +53,13 @@ def get_gradle_provider(
         if brew_pull_enabled:
             alignment_parameters.append("-DrestBrewPullActive=true")
 
-        if temp_prefer_persistent_enabled and suffix_prefix:
+        suffix_prefix_no_temporary = util.strip_temporary_from_prefix(suffix_prefix)
+        # NCLSUP-669: specify the versionSuffixAlternatives if we prefer persistent build alignment for the temp build
+        # and the suffix_prefix without the temporary string is not empty (e.g for managedsvc)
+        if temp_prefer_persistent_enabled and suffix_prefix_no_temporary:
             alignment_parameters.append(
                 "-DversionSuffixAlternatives=redhat,"
-                + util.strip_temporary_from_prefix(suffix_prefix)
+                + suffix_prefix_no_temporary
                 + "-redhat"
             )
 

--- a/repour/adjust/pme_provider.py
+++ b/repour/adjust/pme_provider.py
@@ -70,10 +70,13 @@ def get_pme_provider(
         if brew_pull_enabled:
             alignment_parameters.append("-DrestBrewPullActive=true")
 
-        if temp_prefer_persistent_enabled and suffix_prefix:
+        suffix_prefix_no_temporary = util.strip_temporary_from_prefix(suffix_prefix)
+        # NCLSUP-669: specify the versionSuffixAlternatives if we prefer persistent build alignment for the temp build
+        # and the suffix_prefix without the temporary string is not empty (e.g for managedsvc)
+        if temp_prefer_persistent_enabled and suffix_prefix_no_temporary:
             alignment_parameters.append(
                 "-DversionSuffixAlternatives=redhat,"
-                + util.strip_temporary_from_prefix(suffix_prefix)
+                + suffix_prefix_no_temporary
                 + "-redhat"
             )
 


### PR DESCRIPTION
We should only add versionSuffixAlternatives into the PME and GME CLI if
and only if:
- the temporary build has preferred persistent build alignment
- the suffix-prefix (minus the temporary string) is not empty (e.g for
  managed services)

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
