### PR TITLE
[NCLSUP-626] PME alignment: pass the --f option to PME directly

### DIFF
--- a/repour/adjust/process_provider.py
+++ b/repour/adjust/process_provider.py
@@ -29,7 +29,12 @@ def get_process_provider(
         get_result_data if get_result_data is not None else get_result_data_default
     )
 
-    async def adjust(repo_dir, extra_adjust_parameters, adjust_result, env=None):
+    async def adjust(
+        repo_dir, extra_adjust_parameters, adjust_result, dir_results=None, env=None
+    ):
+        """
+        dir_results is used to define where to get the results data from. By default it is 'repo_dir'
+        """
         # TODO: Why 'adjust_result' is ignored?
         nonlocal execution_name
         logger.info(
@@ -69,11 +74,15 @@ def get_process_provider(
 
         logger.info("Adjust subprocess exited OK!")
 
+        dir_where_results_are = repo_dir
+        if dir_results:
+            dir_where_results_are = dir_results
+
         adjust_result_data = {}
 
         adjust_result_data["adjustType"] = execution_name
         adjust_result_data["resultData"] = await get_result_data(
-            repo_dir, extra_adjust_parameters, results_file=results_file
+            dir_results, extra_adjust_parameters, results_file=results_file
         )
 
         return adjust_result_data

--- a/repour/adjust/util.py
+++ b/repour/adjust/util.py
@@ -166,7 +166,7 @@ def get_extra_parameters(extra_adjust_parameters, flags=("-f", "--file")):
         option_title = re.sub(r"^-*", "", flags[-1])
 
         if getattr(options, option_title) is not None:
-            subfolder = getattr(options, option_title).replace("pom.xml", "")
+            subfolder = getattr(options, option_title)
 
         return remaining_args, subfolder
 

--- a/test/test_adjust_utils.py
+++ b/test/test_adjust_utils.py
@@ -12,13 +12,13 @@ class TestAdjustUtil(unittest.TestCase):
         remaining_args, filepath = util.get_extra_parameters(param)
 
         self.assertEqual(remaining_args, ["-Dtest=test"])
-        self.assertEqual(filepath, "haha/")
+        self.assertEqual(filepath, "haha/pom.xml")
 
-        param_file = {"ALIGNMENT_PARAMETERS": "--file hoho/pom.xml -Dtest=test"}
+        param_file = {"ALIGNMENT_PARAMETERS": "--file hoho/test.xml -Dtest=test"}
 
         remaining_args, filepath = util.get_extra_parameters(param_file)
         self.assertEqual(remaining_args, ["-Dtest=test"])
-        self.assertEqual(filepath, "hoho/")
+        self.assertEqual(filepath, "hoho/test.xml")
 
         param_file_equal = {
             "ALIGNMENT_PARAMETERS": "-Dtest2=test2 --file=hihi -Dtest=test"


### PR DESCRIPTION
Before this commit, Repour would remove the '-f' or '--file' option from
the extra PME parameters and run PME from the folder specified in the
'-f' option. However the PME '-f' option can be used to specify either a
folder or a file (can be named anything, doesn't have to finish with
pom.xml)

This logic unfortunately broke alignment for some projects where the
traditional file that contains the Maven setup is not named pom.xml.

This commit changes this by:
- truly providing the --file option values to PME rather than hiding it
- extracting any folder from the '--file' option to guess where the
  results file will be generated

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
