### PR TITLE
[NCL-7150] Rename levelname to level

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -217,8 +217,8 @@ def adjust_kafka_metadata(data):
             data["@timestamp"] = data["timestamp"]
 
         # NCL-7150: rename fields for consistency
-        if "levelName" in data:
-            data["level"] = data["levelName"]
+        if "levelname" in data:
+            data["level"] = data["levelname"]
         # NCL-7150: rename fields for consistency
         if "host" in data:
             data["hostName"] = data["host"]


### PR DESCRIPTION
Rename 'levelname' to 'level', rather than 'levelName'

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
