### PR TITLE
Revert "[NCLSUP-750] Fetch tags with also '--all' option"

### DIFF
--- a/repour/lib/scm/git.py
+++ b/repour/lib/scm/git.py
@@ -532,7 +532,7 @@ async def add_file(dir, file_path, force=False):
 async def fetch_tags(dir, remote="origin"):
     try:
         await expect_ok(
-            cmd=["git", "fetch", remote, "--tags", "--all"],
+            cmd=["git", "fetch", remote, "--tags"],
             desc="Could not fetch tags with git",
             cwd=dir,
             print_cmd=True,


### PR DESCRIPTION
Reverts project-ncl/repour#479 as build fails with "fatal: fetch --all does not take a repository argument"