### PR TITLE
[v2.4] Hide kafka disconnect errors

### DIFF
--- a/repour/main.py
+++ b/repour/main.py
@@ -208,7 +208,7 @@ def configure_logging(
         logger.info("Setting up Kafka logging handler")
         # we only care if you fail, kafka
         logger_kafka = logging.getLogger("kafka")
-        logger_kafka.setLevel(logging.ERROR)
+        logger_kafka.setLevel(logging.CRITICAL)
 
         kwargs = {}
 


### PR DESCRIPTION
Those errors are printed as ERROR when the kafka broker connection is broken.
```
ERROR [NoContext] <BrokerConnection node_id=2 host=<host> <connected> [IPv4 ('<ip>', 443)]>: socket disconnected
```

The broker eventually reconnects, so is more of an info or warning log. We don't want to have those logs printed as ERROR since they pollute our alerting emails. Therefore, this commit changes the log level for kafka to critical.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
