### PR TITLE
Print stderr in one error log line

### DIFF
--- a/repour/asutil.py
+++ b/repour/asutil.py
@@ -205,20 +205,13 @@ def expect_ok_closure(exc_type=exception.CommandError):
                 "" if stdout_data is None else _convert_bytes(stdout_data, "text")
             )
 
-        if stderr_text != "" and (
-            stderr == "log"
-            or (
-                stderr is not None
-                and stderr.startswith("log_on_error")
-                and p.returncode != 0
-            )
-        ):
-            for line in stderr_text.split("\n"):
-                if line != "":
-                    if stderr == "log_on_error_as_info":
-                        subprocess_logger.info(line)
-                    else:
-                        subprocess_logger.error(line)
+        if stderr_text != "":
+            if stderr == "log_on_error" and p.returncode != 0:
+                subprocess_logger.error(stderr_text)
+            elif stderr == "log_on_error_as_info" and p.returncode != 0:
+                subprocess_logger.info(stderr_text)
+            elif stderr == "log":
+                subprocess_logger.error(stderr_text)
 
         if not p.returncode == 0:
             raise exc_type(

--- a/repour/server/endpoint/endpoint.py
+++ b/repour/server/endpoint/endpoint.py
@@ -79,10 +79,12 @@ def exception_to_obj(exception):
 
 
 def log_traceback_multi_line():
+    """
+
+    Note: Do not try to create one log line per error. This messes up with splunk logging that shows everything per line
+    """
     text = traceback.format_exc()
-    for line in text.split("\n"):
-        if line != "":
-            logger.error(line)
+    logger.error(text)
 
 
 def validated_json_endpoint(shutdown_callbacks, validator, coro, repour_url):


### PR DESCRIPTION
This is done because on Splunk, each error line is shown on the report page and it becomes really hard to follow what is going on. By just printing one big error log line (that may contain newlines), that should make the Repour error logs way more readable.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
