### PR TITLE
handle intentional whitespace in quotes for defaultAlignmentParameters

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import shutil
+import shlex
 
 from prometheus_async.aio import time
 from prometheus_client import Histogram, Summary
@@ -636,8 +637,10 @@ def get_default_alignment_parameters(adjustspec):
     """
     Helper method to extract default alignment parameters as passed in spec and return values in a list.
 
-    for e.g if the params is passed as "key=value key2=value2", then the returned list will be:
-        ["key=value", "key2=value2"]
+    for e.g if the params is passed as "key=value key2=value2 key3='value space'", then the returned list will be:
+        ["key=value", "key2=value2", "key3=value space"]
+
+    Values with whitespace need to be escaped before running shell.
     """
 
     default_alignment_parameters = []
@@ -646,6 +649,6 @@ def get_default_alignment_parameters(adjustspec):
         "defaultAlignmentParams" in adjustspec
         and adjustspec["defaultAlignmentParams"] is not None
     ):
-        default_alignment_parameters = adjustspec["defaultAlignmentParams"].split()
+        default_alignment_parameters = shlex.split(adjustspec["defaultAlignmentParams"])
 
     return default_alignment_parameters

--- a/repour/adjust/process_provider.py
+++ b/repour/adjust/process_provider.py
@@ -2,6 +2,7 @@
 import io
 import logging
 import os
+import shlex
 import zipfile
 
 from repour import asutil, exception
@@ -41,11 +42,13 @@ def get_process_provider(
             'Executing "{execution_name}" using (sub)process adjust provider as: '.format(
                 **locals()
             )
-            + " ".join(cmd)
+            + shlex.join(cmd)
         )
         log_executable_info(cmd)
         filled_cmd = [
-            p.format(repo_dir=repo_dir) if p.startswith("{repo_dir}") else p
+            p.format(repo_dir=repo_dir)
+            if p.startswith("{repo_dir}")
+            else shlex.quote(p)
             for p in cmd
         ]
 


### PR DESCRIPTION
Shlex is a python built-in lexer for unix-like shells that handles spaces in parameters and all escaping to avoid security issues.

If no escaping is required, shlex will leave the properties as is (functioning the same way as before). 

f.e. shlex.quote("-DrestMode=PERSISTENT") == "-DrestMode=PERSISTENT" would be true
f.e  with space, shlex.quote("-DrestDepenencyRanks=PRODUCT_ID : 123 and MILESTONE_ID") == "'-DrestDepenencyRanks=PRODUCT_ID : 123 and MILESTONE_ID'" would be true (shlex escaped the string with ' quotes)

Documentation:
https://docs.python.org/3.8/library/shlex.html#shlex.split
https://docs.python.org/3.8/library/shlex.html#shlex.join
https://docs.python.org/3.8/library/shlex.html#shlex.quote


### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
