### PR TITLE
[NCL-6947] Consider some origin urls as "internal"

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -116,6 +116,9 @@ async def sync_external_repo(adjustspec, repo_provider, work_dir, configuration)
     """
     internal_repo_url = await repo_provider(adjustspec, create=False)
     git_user = configuration.get("git_username")
+    git_origin_repo_urls_internal = configuration.get(
+        "git_origin_repo_urls_internal", []
+    )
 
     is_ref_revision_internal = True
 
@@ -190,6 +193,13 @@ async def sync_external_repo(adjustspec, repo_provider, work_dir, configuration)
     # from the target repository. We need to sync tags because we use it to know if we have tags with existing changes or if we
     # need to create tags of format <version>-<sha> if existing tag with name <version> exists after pme changes
     await git.fetch_tags(work_dir, remote="origin")
+
+    # [NCL-6947] irrespective of the value of is_ref_revision_internal, if the originRepoUrl matches one of the urls in the config
+    # 'git_origin_repo_urls_internal', the ref must be considered internal
+    for url in git_origin_repo_urls_internal:
+        if url in adjustspec["originRepoUrl"]:
+            is_ref_revision_internal = True
+            break
 
     return is_ref_revision_internal
 

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -45,5 +45,6 @@
   },
   "git_username": "",
   "git_url_internal_template": "",
+  "git_origin_urls_internal": [],
   "mode": "devel"
 }


### PR DESCRIPTION
We do sometimes sync from one internal company repository to another internal company repository during alignment. In those cases, the ref should be considered internal no matter what.

To achieve this, we add a new configuration:
- `git_origin_repou_urls_internal` which contains a list of strings as values.
- the values are the urls of the repositories that should be considered internal to the company

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
