### PR TITLE
[NCL-8214] Add taskId to validation for all endpoints

### DIFF
--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -53,6 +53,12 @@ callback_raw = {
 }
 
 callback = Schema({"callback": callback_raw}, required=True, extra=True)
+positive_callback = Schema(
+    {"positiveCallback": callback_raw}, required=True, extra=True
+)
+negative_callback = Schema(
+    {"negativeCallback": callback_raw}, required=True, extra=True
+)
 
 #
 # Adjust
@@ -65,6 +71,8 @@ adjust_raw = {
     Optional("originRepoUrl"): Any(None, str),
     Optional("sync"): bool,
     Optional("callback"): callback_raw,
+    Optional("positiveCallback"): callback_raw,
+    Optional("negativeCallback"): callback_raw,
     Optional("tempBuild"): bool,
     Optional("tempBuildTimestamp"): null_or_str,
     Optional("alignmentPreference"): null_or_str,

--- a/repour/server/endpoint/validation.py
+++ b/repour/server/endpoint/validation.py
@@ -89,6 +89,7 @@ internal_scm = Schema(
         Optional("description"): null_or_str,
         Optional("parent_project"): null_or_str,
         Optional("callback"): callback_raw,
+        Optional("taskId"): null_or_str,
     }
 )
 
@@ -102,6 +103,7 @@ clone_raw = {
     "originRepoUrl": Any(Url(), GitUrl()),  # pylint: disable=no-value-for-parameter
     "targetRepoUrl": Url(),  # pylint: disable=no-value-for-parameter
     Optional("callback"): callback_raw,
+    Optional("taskId"): null_or_str,
 }
 
 clone = Schema(clone_raw, required=True, extra=False)


### PR DESCRIPTION
All endpoints that accept callback should also support the 'taskId' field. It is a unique field that we can then use to 'cancel' the work in progress.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
