### PR TITLE
Hide wrong fatal error during sha check

### DIFF
--- a/repour/lib/scm/git.py
+++ b/repour/lib/scm/git.py
@@ -229,11 +229,13 @@ async def rm(dir, path_in_repository, cached=False):
 
 async def does_sha_exist(dir, ref):
     try:
+        # do not log stderr to output on failure. this causes useless error logs to be printed if ref is not a branch
         await expect_ok(
             cmd=["git", "cat-file", "-e", ref + "^{commit}"],
             cwd=dir,
             desc="Ignore this.",
             print_cmd=True,
+            stderr=None,
         )
         return True
     except Exception:


### PR DESCRIPTION
If during a sha check, it fails, we print a fatal error even though we shouldn't.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
