### PR TITLE
[NCLSUP-1136] Sanitize project path for gitlab

### DIFF
--- a/repour/server/endpoint/internal_scm_gitlab.py
+++ b/repour/server/endpoint/internal_scm_gitlab.py
@@ -8,6 +8,30 @@ from repour.lib.scm import gitlab as scm_gitlab
 logger = logging.getLogger(__name__)
 
 
+def sanitize_gitlab_name(name):
+    """
+    gitlab doesn't like the start or end of a project or subgroup to be something other than
+    alpha numeric. If this happens, let's just replace the non-alpha-numeric character with an underscore
+    """
+
+    list_name = list(name)
+    if not list_name[0].isalnum():
+        list_name[0] = "_"
+    if not list_name[-1].isalnum():
+        list_name[-1] = "_"
+
+    return "".join(list_name)
+
+
+def sanitize_gitlab_project_path(project_path):
+    (subgroup_name, project_name) = project_path.split("/", 1)
+
+    sanitized_subgroup_name = sanitize_gitlab_name(subgroup_name)
+    sanitized_project_name = sanitize_gitlab_name(project_name)
+
+    return sanitized_subgroup_name + "/" + sanitized_project_name
+
+
 async def internal_scm_gitlab(spec, repo_provider):
     """
     spec looks like validation.internal_scm_gitlab
@@ -24,7 +48,7 @@ async def internal_scm_gitlab(spec, repo_provider):
     readonly_url = gitlab_config.get("read_only_template")
     readwrite_url = gitlab_config.get("read_write_template")
 
-    project_path = spec.get("project")
+    project_path = sanitize_gitlab_project_path(spec.get("project"))
     if "/" in project_path:
         (subgroup_name, project_name) = project_path.split("/", 1)
         if "/" in project_name:

--- a/test/test_internal_scm_gitlab.py
+++ b/test/test_internal_scm_gitlab.py
@@ -1,0 +1,15 @@
+# flake8: noqa
+import unittest
+import repour.server.endpoint.internal_scm_gitlab as internal_scm_gitlab
+
+
+class TestInternalSCMGitlab(unittest.TestCase):
+    def test_internal_scm_gitlab(self):
+        result = internal_scm_gitlab.sanitize_gitlab_project_path("Qix-/color-convert")
+        self.assertEqual(result, "Qix_/color-convert")
+
+        result = internal_scm_gitlab.sanitize_gitlab_project_path("-Qix/color-convert")
+        self.assertEqual(result, "_Qix/color-convert")
+
+        result = internal_scm_gitlab.sanitize_gitlab_project_path("Qix/color-convert-")
+        self.assertEqual(result, "Qix/color-convert_")


### PR DESCRIPTION
Gitlab has a particular regex format for group and project name. We need to modify the path we receive to adhere to that format.

Most of the paths we receive are from Github and Github probably has different naming requirements compared to Gitlab.

If the start or end of the group/project ends with a non-alpha-numeric character, we'll just replace it with an underscore.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
