### PR TITLE
[NCLSUP-1166] Add delay before running alignment

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -275,6 +275,13 @@ async def adjust(adjustspec, repo_provider):
 
         process_mdc("BEGIN", "ALIGNMENT_ADJUST")
 
+        # NCLSUP-1166: add delay before adjust starts to account for a Rex bug
+        adjust_delay_seconds = c.get("adjust_delay_seconds", 0)
+        logger.info(
+            "Sleeping for " + str(adjust_delay_seconds) + " before running alignment"
+        )
+        await asyncio.sleep(adjust_delay_seconds)
+
         ### Adjust Phase ###
         if build_type == "MVN":
             specific_tag_name = await adjust_mvn(work_dir, c, adjustspec, adjust_result)

--- a/repour/config/default-config.json
+++ b/repour/config/default-config.json
@@ -63,5 +63,6 @@
   },
   "git_origin_urls_internal": [],
   "git_backend": "gerrit",
-  "mode": "devel"
+  "mode": "devel",
+  "adjust_delay_seconds": 10
 }


### PR DESCRIPTION
We want to add a configurable delay before running alignment due to a bug in Rex which doesn't account for the time it takes for a build to be entirely stored in PNC.

The delay will give a chance for PNC to store the results before progressing. Once the Rex bug is fixed, we can remove that code.

This is set in the config.json by specifying:
```
    "adjust_delay_seconds": 100
```

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
