### PR TITLE
Allow user to override the value of adjust-delay-seconds

### DIFF
--- a/repour/adjust/adjust.py
+++ b/repour/adjust/adjust.py
@@ -277,6 +277,10 @@ async def adjust(adjustspec, repo_provider):
 
         # NCLSUP-1166: add delay before adjust starts to account for a Rex bug
         adjust_delay_seconds = c.get("adjust_delay_seconds", 0)
+        extra_adjust_parameters = adjustspec.get("adjustParameters", {})
+
+        if "ADJUST_DELAY_SECONDS" in extra_adjust_parameters:
+            adjust_delay_seconds = int(extra_adjust_parameters["ADJUST_DELAY_SECONDS"])
 
         if adjust_delay_seconds > 0:
             logger.info(


### PR DESCRIPTION
This can be specified by the user in PNC via the generic parameters (currently only via bacon's build-config.yaml)

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
