### PR TITLE
Fix deprecation warning and disappearance of asyncio.Task.all_tasks

### DIFF
--- a/repour/server/endpoint/cancel.py
+++ b/repour/server/endpoint/cancel.py
@@ -161,7 +161,7 @@ async def remove_old_cancel_indicator_files():
 
 
 def get_task_id_dict():
-    all_tasks = asyncio.Task.all_tasks()
+    all_tasks = asyncio.all_tasks(asyncio.get_running_loop())
     task_id_dict = {}
 
     for task in all_tasks:

--- a/repour/server/server.py
+++ b/repour/server/server.py
@@ -116,7 +116,7 @@ def start_server(bind, repo_provider, repour_url, adjust_provider):
         logger.debug("KeyboardInterrupt")
     finally:
         logger.info("Stopping tasks and shutting down")
-        tasks = asyncio.Task.all_tasks()
+        tasks = asyncio.all_tasks(asyncio.get_running_loop())
         for task in tasks:
             task.cancel()
         results = loop.run_until_complete(


### PR DESCRIPTION
Depending on the Python version we are using, `asyncio.Task.all_tasks` is either deprecated or completely removed. This commit resolves it by using the non-deprecated method instead.

### All Submissions:

* [ ] Have you added a note in the [CHANGELOG wiki](https://github.com/project-ncl/repour/wiki/Changelog) for your change?
* [ ] Have you added unit tests for your change?
